### PR TITLE
add bettercalamba to lgu directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A community-maintained directory of **Better LGU** digital transparency portals 
 | San Pascual, Masbate | — | [GitHub](https://github.com/marcuwynu23/bettersanpascualmasbate)| — | 🟡 Work in Progress | [@marcuwynu23](https://github.com/marcuwynu23) |
 | Teresa, Rizal | — | — | — | 🔵 Planned | [@MewSeiren](https://github.com/MewSeiren) |
 | Atimonan, Quezon | — | [GitHub](https://github.com/EmsiPrds/betteratimonan)  | — | 🔵 Planned | [@EmsiPrds](https://github.com/EmsiPrds) |
-
+| Calamba, Laguna | — | — | — | 🔵 Planned | [@apajuan](https://github.com/apajuan) |
 <!-- SYNC_LGU_TABLE_END -->
 
 > Want to add your LGU? See the [Contributing Guide](CONTRIBUTING.md).


### PR DESCRIPTION
## Add bettercalamba (Calamba, Laguna) to BetterLGU Directories

## Description

- **LGU Name:** Calamba, Laguna
- **Domain:** —
- **Repository Link:** —
- **Facebook Page Link:** —
- **Status:** Planned
- **Maintainer GitHub Handle/s:** [@apajuan](https://github.com/apajuan)

## Checklist

- [x] I have added/updated the entry in the `README.md` directory table.
- [x] The status badge is correct according to the [Status Legend](README.md#status-legend).
- [x] All blank fields use `—` instead of being left empty.
- [x] All maintainer handles are linked to their GitHub profiles.
