### PR TITLE
docs: update cabanatuan status from planned to wip and added the github repo link of bettercabanatuan

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ A community-maintained directory of **Better LGU** digital transparency portals 
 | Atimonan, Quezon | — | [GitHub](https://github.com/EmsiPrds/betteratimonan)  | — | 🔵 Planned | [@EmsiPrds](https://github.com/EmsiPrds) |
 | Dinalupihan, Bataan | - | - | - | 🔵 Planned | [@dardeejay](https://github.com/dardeejay) |
 | Calamba, Laguna | — | — | — | 🔵 Planned | [@apajuan](https://github.com/apajuan) |
-| Cabanatuan City, Nueva Ecija | — | — | — | 🔵 Planned | [@joshuagemvicente](https://github.com/joshuagemvicente), [@iampoll](https://github.com/iampoll) |
+| Cabanatuan City, Nueva Ecija | — | [GitHub](https://github.com/BetterCabanatuan/bettercabanatuan) | — | 🟡 Work in Progress | [@joshuagemvicente](https://github.com/joshuagemvicente), [@iampoll](https://github.com/iampoll) |
 | Angeles City, Pampanga | — | [GitHub](https://github.com/ongods/betterangeles) | — | 🔵 Planned | [@ongods](https://github.com/ongods) |
 
 <!-- SYNC_LGU_TABLE_END -->


### PR DESCRIPTION


## Description

Please provide the details for the LGU entry being added or updated.

- **LGU Name: Cabanatuan City, Nueva Ecija**
- **Domain: - **
- **Repository Link: [BetterCabanatuan Repository Link](https://github.com/BetterCabanatuan/bettercabanatuan)**
- **Facebook Page Link: - **
- **Status: Work in Progress** (Planned / Work in Progress / Active / Unmaintained)
- **Maintainer GitHub Handle/s: [@joshuagemvicente](https://github.com/joshuagemvicente), [@iampoll](https://github.com/iampoll)**

## Checklist

- [x] I have added/updated the entry in the `README.md` directory table.
- [x] The status badge is correct according to the [Status Legend](README.md#status-legend).
- [x] All blank fields use `—` instead of being left empty.
- [x] All maintainer handles are linked to their GitHub profiles.
