### PR TITLE
feat: convert Facebook column to Socials column (#66)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ Please provide the details for the LGU entry being added or updated.
 - **LGU Name:**
 - **Domain:**
 - **Repository Link:**
-- **Facebook Page Link:**
+- **Social Links:**
 - **Status:** (Planned / Work in Progress / Active / Unmaintained)
 - **Maintainer GitHub Handle/s:**
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,29 @@
+# Better LGU Directory
+
+A community-maintained directory of Better LGU transparency portals. The canonical record is the LGU table in `README.md` on the `main` branch; a sync pipeline projects it into a Jekyll site on the `main-pages` branch.
+
+## Language
+
+**LGU**:
+A Philippine Local Government Unit that has (or plans) a Better LGU transparency portal. One row in the directory.
+_Avoid_: city, municipality, town (use LGU for the directory entry).
+
+**Entry**:
+A single row in the LGU table — the unit contributors add or update via PR.
+_Avoid_: record, item, listing.
+
+**Social**:
+A single labeled link to an LGU's presence on one social platform (e.g. a Facebook page). The platform is identified by the link's label text, normalized lowercase.
+_Avoid_: Facebook (a Social is platform-agnostic; Facebook is just one platform).
+
+**Socials**:
+The set of Socials for one LGU — the directory column (formerly "Facebook"). May hold zero or more Socials. Empty renders as `-`.
+_Avoid_: Facebook column, social media links.
+
+**Platform**:
+The social network a Social points to (facebook, x, instagram, linkedin, youtube, tiktok, bluesky). Determined from the Social's label, not the URL host; an unknown label falls back to a generic icon.
+_Avoid_: network, provider, site.
+
+**Sync pipeline**:
+The `main` → `main-pages` projection: `scripts/sync-to-data.js` parses the `README.md` table into `_data/lgus.yml`, which `index.md` renders. `README.md` is the source of truth; `_data/lgus.yml` is generated and never hand-edited.
+_Avoid_: build, import.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@ You do not need to have a finished portal to register. If you are planning to bu
    | Your LGU Name | [yourdomain.org](https://yourdomain.org) or — | [GitHub](https://github.com/you/repo) or — | [Facebook](https://facebook.com/yourpage) or — | 🔵 Planned | [@yourhandle](https://github.com/yourhandle) |
    ```
 
+   The **Socials** column accepts one or more platform links. Multiple links are comma-separated, e.g. `[Facebook](https://facebook.com/yourpage), [X](https://x.com/yourhandle)`.
+
    Use `—` for any field that does not apply yet.
 
 3. **Choose the correct status badge:**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # BetterGov.ph — LGU Directory
 
-A community-maintained directory of **Better LGU** digital transparency portals across the Philippines — find an existing portal before you build, contribute to one, or start your own. Each entry links to the LGU's portal, source repository, and Facebook page, along with its current maintenance status.
+A community-maintained directory of **Better LGU** digital transparency portals across the Philippines — find an existing portal before you build, contribute to one, or start your own. Each entry links to the LGU's portal, source repository, and social pages, along with its current maintenance status.
 
 ---
 
@@ -8,7 +8,7 @@ A community-maintained directory of **Better LGU** digital transparency portals 
 
 <!-- SYNC_LGU_TABLE_START -->
 
-| LGU                                 | Domain                                                | Repository                                                                     | Facebook                                                           | Status    | Maintainer/s                                                                           |
+| LGU                                 | Domain                                                | Repository                                                                     | Socials                                                            | Status    | Maintainer/s                                                                           |
 |-------------------------------------|-------------------------------------------------------|--------------------------------------------------------------------------------|--------------------------------------------------------------------|-----------|----------------------------------------------------------------------------------------|
 | Solano, Nueva Vizcaya               | [bettersolano.org](https://bettersolano.org)          | [GitHub](https://github.com/BetterSolano/bettersolano)                         | [Facebook](https://www.facebook.com/bettersolano.org)              | 🟢 Active | [@ramonloganjr](https://github.com/ramonloganjr)                                       |
 | Bacolod City, Negros Occidental     | [betterbacolod.org](https://betterbacolod.org)        | [GitHub](https://github.com/betterbacolod/betterbacolod)                       | [Facebook](https://www.facebook.com/betterbacolod.org)             | 🟢 Active | [@mattenarle10](https://github.com/mattenarle10)                                       |

--- a/scripts/sync-to-data.js
+++ b/scripts/sync-to-data.js
@@ -6,6 +6,13 @@ const LGUS_DATA_PATH = process.argv[2] || path.join(__dirname, '../_data/lgus.ym
 
 const VALID_STATUSES = ['🟢 Active', '🟡 Work in Progress', '🔴 Unmaintained', '🔵 Planned'];
 
+const EMPTY_MARKERS = ['', '-', '—', '–'];
+
+// Escape a value for safe embedding inside a double-quoted YAML scalar.
+function yamlStr(value) {
+    return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
 function parseTable(content, startMarker, endMarker) {
     const startIdx = content.indexOf(startMarker);
     const endIdx = content.indexOf(endMarker);
@@ -27,11 +34,12 @@ function parseTable(content, startMarker, endMarker) {
 }
 
 function parseSocials(cell) {
-    if (!cell || cell === '-' || cell === '—' || cell === '–') {
+    if (EMPTY_MARKERS.includes(cell)) {
         return [];
     }
 
-    const linkPattern = /\[([^\]]+)\]\(([^)]+)\)/g;
+    // URL group allows one level of nested parens, e.g. ..._(Philippines)
+    const linkPattern = /\[([^\]]+)\]\(([^)]*(?:\([^)]*\)[^)]*)*)\)/g;
     const socials = [];
     let match;
 
@@ -60,6 +68,9 @@ function validateLgu(cells, index) {
     }
 
     const socials = parseSocials(socialsCell);
+    if (socials.length === 0 && !EMPTY_MARKERS.includes(socialsCell)) {
+        throw new Error(`LGU Table Row ${index + 1} has a Socials cell with no valid [label](url) links: "${socialsCell}".`);
+    }
 
     return { name, domain, repo, socials, status, maintainer };
 }
@@ -70,9 +81,9 @@ function formatSocialsYaml(socials) {
     }
     const lines = ['  socials:'];
     for (const s of socials) {
-        lines.push(`    - platform: "${s.platform}"`);
-        lines.push(`      label: "${s.label}"`);
-        lines.push(`      url: "${s.url}"`);
+        lines.push(`    - platform: "${yamlStr(s.platform)}"`);
+        lines.push(`      label: "${yamlStr(s.label)}"`);
+        lines.push(`      url: "${yamlStr(s.url)}"`);
     }
     return lines.join('\n');
 }
@@ -95,12 +106,12 @@ try {
     // Write to YAML
     const lguYaml = lgus.map(l => {
         return [
-            `- name: "${l.name}"`,
-            `  domain: "${l.domain}"`,
-            `  repo: "${l.repo}"`,
+            `- name: "${yamlStr(l.name)}"`,
+            `  domain: "${yamlStr(l.domain)}"`,
+            `  repo: "${yamlStr(l.repo)}"`,
             formatSocialsYaml(l.socials),
-            `  status: "${l.status}"`,
-            `  maintainer: "${l.maintainer}"`,
+            `  status: "${yamlStr(l.status)}"`,
+            `  maintainer: "${yamlStr(l.maintainer)}"`,
         ].join('\n');
     }).join('\n');
 

--- a/scripts/sync-to-data.js
+++ b/scripts/sync-to-data.js
@@ -1,0 +1,113 @@
+const fs = require('fs');
+const path = require('path');
+
+const README_PATH = path.join(__dirname, '../README.md');
+const LGUS_DATA_PATH = process.argv[2] || path.join(__dirname, '../_data/lgus.yml');
+
+const VALID_STATUSES = ['🟢 Active', '🟡 Work in Progress', '🔴 Unmaintained', '🔵 Planned'];
+
+function parseTable(content, startMarker, endMarker) {
+    const startIdx = content.indexOf(startMarker);
+    const endIdx = content.indexOf(endMarker);
+
+    if (startIdx === -1 || endIdx === -1) {
+        throw new Error(`Markers ${startMarker} or ${endMarker} not found in README.md`);
+    }
+
+    const tableContent = content.substring(startIdx + startMarker.length, endIdx).trim();
+    const rows = tableContent.split('\n').filter(row => row.trim().startsWith('|'));
+
+    // Skip header and separator
+    const dataRows = rows.slice(2);
+
+    return dataRows.map((row) => {
+        const cells = row.split('|').map(cell => cell.trim()).filter((_, i, arr) => i > 0 && i < arr.length - 1);
+        return cells;
+    });
+}
+
+function parseSocials(cell) {
+    if (!cell || cell === '-' || cell === '—' || cell === '–') {
+        return [];
+    }
+
+    const linkPattern = /\[([^\]]+)\]\(([^)]+)\)/g;
+    const socials = [];
+    let match;
+
+    while ((match = linkPattern.exec(cell)) !== null) {
+        const label = match[1].trim();
+        const url = match[2].trim();
+        const platform = label.toLowerCase().trim();
+        socials.push({ platform, label, url });
+    }
+
+    return socials;
+}
+
+function validateLgu(cells, index) {
+    if (cells.length < 6) {
+        throw new Error(`LGU Table Row ${index + 1} is malformed (missing columns).`);
+    }
+    const [name, domain, repo, socialsCell, status, maintainer] = cells;
+
+    if (!name || name === '—') {
+        throw new Error(`LGU Table Row ${index + 1} is missing a name.`);
+    }
+
+    if (!VALID_STATUSES.includes(status)) {
+        throw new Error(`LGU Table Row ${index + 1} has an invalid status: "${status}".`);
+    }
+
+    const socials = parseSocials(socialsCell);
+
+    return { name, domain, repo, socials, status, maintainer };
+}
+
+function formatSocialsYaml(socials) {
+    if (socials.length === 0) {
+        return '  socials: []';
+    }
+    const lines = ['  socials:'];
+    for (const s of socials) {
+        lines.push(`    - platform: "${s.platform}"`);
+        lines.push(`      label: "${s.label}"`);
+        lines.push(`      url: "${s.url}"`);
+    }
+    return lines.join('\n');
+}
+
+try {
+    console.log('🚀 Starting sync from README.md to LGU Data...');
+    const readmeContent = fs.readFileSync(README_PATH, 'utf8');
+
+    // Parse LGUs
+    const rawLgus = parseTable(readmeContent, '<!-- SYNC_LGU_TABLE_START -->', '<!-- SYNC_LGU_TABLE_END -->');
+    const lgus = rawLgus.map(validateLgu);
+    console.log(`✅ Validated ${lgus.length} LGU entries.`);
+
+    // Ensure directory exists
+    const dataDir = path.dirname(LGUS_DATA_PATH);
+    if (!fs.existsSync(dataDir)) {
+        fs.mkdirSync(dataDir, { recursive: true });
+    }
+
+    // Write to YAML
+    const lguYaml = lgus.map(l => {
+        return [
+            `- name: "${l.name}"`,
+            `  domain: "${l.domain}"`,
+            `  repo: "${l.repo}"`,
+            formatSocialsYaml(l.socials),
+            `  status: "${l.status}"`,
+            `  maintainer: "${l.maintainer}"`,
+        ].join('\n');
+    }).join('\n');
+
+    fs.writeFileSync(LGUS_DATA_PATH, lguYaml);
+    console.log(`🎉 Success! Data synchronized to ${LGUS_DATA_PATH}`);
+
+} catch (error) {
+    console.error(`\n❌ SYNC FAILED: ${error.message}`);
+    process.exit(1);
+}


### PR DESCRIPTION
## Summary

Part of #66.

Generalises the single-platform `Facebook` column in the source-of-truth `README.md` into a multi-platform `Socials` column, and rewires the sync script to emit a structured YAML schema instead of a raw string.

### Changes

- **README.md** — renames table header `Facebook` → `Socials`; updates the intro sentence ("Facebook page" → "social pages"); existing `[Facebook](url)` cell values are left as-is.
- **scripts/sync-to-data.js** (new on `main`) — replaces the `facebook` string field with a parsed `socials` list. Each `[Label](url)` pair in the cell becomes `{ platform, label, url }` (multiple links are comma-separated). Empty / dash cells emit `socials: []`. Required column count and `VALID_STATUSES` checks are unchanged.
- **CONTRIBUTING.md** — updates the example table row note to reference the `Socials` column and documents comma-separated multi-link syntax.
- **.github/PULL_REQUEST_TEMPLATE.md** — renames the field label from `Facebook Page Link` to `Social Links`.

### New YAML schema emitted by sync

```yaml
- name: "Solano, Nueva Vizcaya"
  domain: "..."
  repo: "..."
  socials:
    - platform: "facebook"
      label: "Facebook"
      url: "https://www.facebook.com/bettersolano.org"
  status: "🟢 Active"
  maintainer: "..."
```

LGUs with no social links:

```yaml
  socials: []
```

### Quality gate

`node scripts/sync-to-data.js /tmp/lgus-test-66.yml` — exit 0, 45 entries validated, 16 with structured socials, 29 with `socials: []`.