### PR TITLE
fix(sync): normalize empty cells to a uniform dash

### DIFF
--- a/scripts/sync-to-data.js
+++ b/scripts/sync-to-data.js
@@ -13,6 +13,12 @@ function yamlStr(value) {
     return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
+// Normalize a "no value" cell to a single uniform dash so the rendered
+// table doesn't mix hyphens and em/en dashes.
+function normalizeDash(value) {
+    return EMPTY_MARKERS.includes((value || '').trim()) ? '-' : value;
+}
+
 function parseTable(content, startMarker, endMarker) {
     const startIdx = content.indexOf(startMarker);
     const endIdx = content.indexOf(endMarker);
@@ -72,7 +78,14 @@ function validateLgu(cells, index) {
         throw new Error(`LGU Table Row ${index + 1} has a Socials cell with no valid [label](url) links: "${socialsCell}".`);
     }
 
-    return { name, domain, repo, socials, status, maintainer };
+    return {
+        name,
+        domain: normalizeDash(domain),
+        repo: normalizeDash(repo),
+        socials,
+        status,
+        maintainer: normalizeDash(maintainer),
+    };
 }
 
 function formatSocialsYaml(socials) {


### PR DESCRIPTION
Empty/placeholder cells in the README table are authored inconsistently as `-`, `—`, or `–`, which renders as mixed dashes in the directory.

Adds `normalizeDash()` to `scripts/sync-to-data.js` so empty `domain`/`repo`/`maintainer` cells emit a single uniform `-` in the synced data (Socials already renders `-` for empty). Verified: regenerated data has 37 uniform `-`, zero em/en dashes.

This is the source-of-truth copy of the fix — the same change was applied directly to `main-pages` for the live site; putting it on `main` keeps the script (which the sync workflow runs from `main`'s tree) from drifting back to em-dashes on the next merge.