### PR TITLE
docs(changelog): add Unreleased entry (becomes 1.1.0 on 2026-07-06)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,13 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **37 new LGU entries**: Indang, General Santos City, Dasmariñas City, General Trias, San Pedro, Cabuyao City, Tuguegarao, Davao City, Allen, Aparri, San Pablo, Binangonan, Taytay, Tanza, Olongapo City, Biñan, Tanay, Puerto Princesa City, Iligan City, Hilongos, Limay, Antique, Libmanan, Teresa, Atimonan, San Pascual, Dinalupihan, Calamba, Angeles City, Cabanatuan City, Piat, Cebu City, Alaminos City, Koronadal City, Santo Tomas, Legazpi, and Santa Barbara.
 
 ### Changed
-- Renamed the `Facebook` column to `Socials`, and updated `CONTRIBUTING.md` and the pull request template to match (socials are comma-separated).
+- Renamed the `Facebook` column to `Socials`, and updated `CONTRIBUTING.md`, the pull request template, and the update-entry issue template to match (socials are comma-separated).
 - Reframed the directory introduction toward a builder audience.
 - Expanded the Getting Started steps and added a directory deduplication gate to the guide; refreshed the tech stack and examples.
 - Numerous LGU status transitions as portals progressed (Planned → Work in Progress → Active), including Aparri, Allen, San Pablo, Libmanan, Iligan City, Cabanatuan City, Atimonan, San Pascual, and Calamba.
 
 ### Fixed
-- Normalized empty directory cells to a uniform dash.
+- Normalized empty directory cells to a uniform dash, and aligned contributor guidance to use a single `-`.
 - Hardened the README → data sync: YAML escaping, detection of malformed Socials cells, and URL parsing for links containing parentheses.
 - Fixed social icons not rendering inside Markdown table cells, and restored their hover colors.
 - Fixed the sync workflow to push merge commits even when there are no data changes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > [!NOTE]
 > This file is updated by the repository maintainers. Contributors are requested to **not** update the `CHANGELOG.md` in their Pull Requests.
 
+## [1.1.0] - 2026-07-06
+
+### Added
+- **Multi-platform Socials**: the directory's `Facebook` column is now a `Socials` column that supports multiple social links per LGU — Facebook, X, Instagram, LinkedIn, YouTube, TikTok, and Bluesky — rendered as platform icons on the website, with a generic fallback for any other link.
+- **Automated README → website sync**: a GitHub Actions workflow keeps the published website data in sync with the directory table in `README.md`.
+- **37 new LGU entries**: Indang, General Santos City, Dasmariñas City, General Trias, San Pedro, Cabuyao City, Tuguegarao, Davao City, Allen, Aparri, San Pablo, Binangonan, Taytay, Tanza, Olongapo City, Biñan, Tanay, Puerto Princesa City, Iligan City, Hilongos, Limay, Antique, Libmanan, Teresa, Atimonan, San Pascual, Dinalupihan, Calamba, Angeles City, Cabanatuan City, Piat, Cebu City, Alaminos City, Koronadal City, Santo Tomas, Legazpi, and Santa Barbara.
+
+### Changed
+- Renamed the `Facebook` column to `Socials`, and updated `CONTRIBUTING.md` and the pull request template to match (socials are comma-separated).
+- Reframed the directory introduction toward a builder audience.
+- Expanded the Getting Started steps and added a directory deduplication gate to the guide; refreshed the tech stack and examples.
+- Numerous LGU status transitions as portals progressed (Planned → Work in Progress → Active), including Aparri, Allen, San Pablo, Libmanan, Iligan City, Cabanatuan City, Atimonan, San Pascual, and Calamba.
+
+### Fixed
+- Normalized empty directory cells to a uniform dash.
+- Hardened the README → data sync: YAML escaping, detection of malformed Socials cells, and URL parsing for links containing parentheses.
+- Fixed social icons not rendering inside Markdown table cells, and restored their hover colors.
+- Fixed the sync workflow to push merge commits even when there are no data changes.
+- Fixed a broken Better Solano Starter link and a repository link in the registration instructions.
+
 ## [1.0.0] - 2026-04-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > [!NOTE]
 > This file is updated by the repository maintainers. Contributors are requested to **not** update the `CHANGELOG.md` in their Pull Requests.
 
-## [1.1.0] - 2026-07-06
+## [Unreleased]
 
 ### Added
 - **Multi-platform Socials**: the directory's `Facebook` column is now a `Socials` column that supports multiple social links per LGU — Facebook, X, Instagram, LinkedIn, YouTube, TikTok, and Bluesky — rendered as platform icons on the website, with a generic fallback for any other link.


### PR DESCRIPTION
Adds the `1.1.0` changelog entry covering everything since `1.0.0` (2026-04-06), dated for the 2026-07-06 release.

**Highlights**
- Multi-platform Socials column (Facebook → Socials, icon rendering)
- Automated README → website sync workflow
- 37 new LGU entries
- Sync hardening + rendering/dash fixes

Compiled from merged PRs on `main` since the 1.0.0 launch.