### PR TITLE
docs: align contributor guidance with Socials rename + dash normalization

### DIFF
--- a/.github/ISSUE_TEMPLATE/update-entry.md
+++ b/.github/ISSUE_TEMPLATE/update-entry.md
@@ -8,7 +8,7 @@ labels: update
 [Provide the name of the LGU as it appears in the directory]
 
 ### What is changing?
-[e.g. Status, Domain, Repository, Maintainers]
+[e.g. Status, Domain, Repository, Socials, Maintainers]
 
 ### Old Value
 [The current value in the directory]

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,5 +13,5 @@ Please provide the details for the LGU entry being added or updated.
 
 - [ ] I have added/updated the entry in the `README.md` directory table.
 - [ ] The status badge is correct according to the [Status Legend](README.md#status-legend).
-- [ ] All blank fields use `—` instead of being left empty.
+- [ ] All blank fields use `-` instead of being left empty.
 - [ ] All maintainer handles are linked to their GitHub profiles.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,12 +15,12 @@ You do not need to have a finished portal to register. If you are planning to bu
 2. **Edit `README.md`** and add a row to the Directory table:
 
    ```markdown
-   | Your LGU Name | [yourdomain.org](https://yourdomain.org) or — | [GitHub](https://github.com/you/repo) or — | [Facebook](https://facebook.com/yourpage) or — | 🔵 Planned | [@yourhandle](https://github.com/yourhandle) |
+   | Your LGU Name | [yourdomain.org](https://yourdomain.org) or - | [GitHub](https://github.com/you/repo) or - | [Facebook](https://facebook.com/yourpage) or - | 🔵 Planned | [@yourhandle](https://github.com/yourhandle) |
    ```
 
    The **Socials** column accepts one or more platform links. Multiple links are comma-separated, e.g. `[Facebook](https://facebook.com/yourpage), [X](https://x.com/yourhandle)`.
 
-   Use `—` for any field that does not apply yet.
+   Use `-` for any field that does not apply yet.
 
 3. **Choose the correct status badge:**
 


### PR DESCRIPTION
Follow-up doc fixes for two earlier changes that didn't update contributor-facing guidance:

- **Dash normalization (#70)**: the site now renders all empty cells as a plain `-`, but `CONTRIBUTING.md` and the PR template still told contributors to use the em dash `—`. Switched both to `-`.
- **Socials rename (#67)**: `update-entry.md` issue template didn't list Socials as a changeable field. Added it.

Not release-specific — these are missed updates from the respective PRs.