### PR TITLE
docs(guide): document Discord reporting webhook integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Multi-platform Socials**: the directory's `Facebook` column is now a `Socials` column that supports multiple social links per LGU — Facebook, X, Instagram, LinkedIn, YouTube, TikTok, and Bluesky — rendered as platform icons on the website, with a generic fallback for any other link.
 - **Automated README → website sync**: a GitHub Actions workflow keeps the published website data in sync with the directory table in `README.md`.
+- **Discord reporting integration guide**: `GUIDE.md` now documents how maintainers can funnel citizen reports, feedback, or logs into the BetterGov.ph Discord via webhook — including the bot-protection prerequisite (reCAPTCHA, Turnstile, or rate-limiting) required before the mods issue a webhook URL.
 - **37 new LGU entries**: Indang, General Santos City, Dasmariñas City, General Trias, San Pedro, Cabuyao City, Tuguegarao, Davao City, Allen, Aparri, San Pablo, Binangonan, Taytay, Tanza, Olongapo City, Biñan, Tanay, Puerto Princesa City, Iligan City, Hilongos, Limay, Antique, Libmanan, Teresa, Atimonan, San Pascual, Dinalupihan, Calamba, Angeles City, Cabanatuan City, Piat, Cebu City, Alaminos City, Koronadal City, Santo Tomas, Legazpi, and Santa Barbara.
 
 ### Changed

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -109,6 +109,17 @@ A transparency portal is only valuable if it stays current. Consider:
 - Recruiting co-maintainers from your local tech community
 - Connecting with other Better LGU maintainers in the BetterGov.ph community for support
 
+### Funnel Reports to the Community Discord
+
+Once your portal has a live intake surface (a citizen report or feedback form), you can pipe submissions — citizen reports, feedback, or system logs — into a dedicated channel in the BetterGov.ph Discord via webhook, so the wider community can see and help triage them. This is optional and only relevant after launch.
+
+**Before you request a webhook, your report intake must already be protected against automated abuse.** Webhook access is granted only to portals that can demonstrate this. There is no single required tool — the goal is simply that a bot cannot flood the channel through your form. Common ways to meet the bar:
+
+- A CAPTCHA on the form (Google reCAPTCHA, Cloudflare Turnstile, or similar)
+- Edge rate-limiting (e.g. Cloudflare) or application-level throttling on the submit endpoint
+
+When your protection is in place, reach out to the Discord Mod team through the BetterGov.ph community channels — they provision the channel and issue the webhook URL, and make the final call on whether your measures are sufficient.
+
 ---
 
 ## Need Help?


### PR DESCRIPTION
## What

Adds an optional, post-launch subsection to `GUIDE.md` — **Funnel Reports to the Community Discord** — under *Keeping It Maintained*, plus an `[Unreleased]` CHANGELOG entry.

## Why

Responds to the BetterGov.ph Discord announcement about dedicated automated-reporting channels. The announcement targets Better LGU **instances** (portals with citizen-report intake), not this directory — so the directory's role is to **document** the integration and its eligibility gate, not to integrate anything itself.

## Decisions

- **Documentation, not integration** — the directory has no report surface; the security requirement (bot protection) only makes sense on an instance's form.
- **Non-prescriptive gate** — states the required outcome (spam-proof intake), lists reCAPTCHA / Cloudflare Turnstile / rate-limiting as examples, and names the Discord mods as the authority that judges sufficiency.
- **Placement** — subsection under *Keeping It Maintained*, not the Step 1–7 launch flow, since it's optional and post-launch.
- **`CONTEXT.md` untouched** — these are instance runtime concepts with no directory-model referent. A future `INTEGRATIONS.md` is the promotion path if a second integration lands.