### PR TITLE
Add City of Manila to directory 🟡 Work in Progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ A community-maintained directory of **Better LGU** digital transparency portals 
 | Midsayap, North Cotabato | - | - | - | 🔵 Planned | [@PostNZT](https://github.com/PostNZT) |
 | Tandag City, Surigao del Sur | — | [Github](https://github.com/BetterTandag/better-tandag) | — | 🟡 Work in Progress | [@ikmespinoza](https://github.com/ikmespinoza) |
 | Baler, Aurora | - | - | - | 🔵 Planned | [@bjtecuico](https://github.com/bjtecuico) |
+| City of Manila, Metro Manila | [bettermanila.org](https://bettermanila.org) | [GitHub](https://github.com/grgdlm/bettermanila) | - | 🟡 Work in Progress | [@grgdlm](https://github.com/grgdlm) |
 
 <!-- SYNC_LGU_TABLE_END -->
 


### PR DESCRIPTION
## Description

Registering the City of Manila in the directory. The portal is being built on the Better Local Gov starter kit (`iyanski/betterlocalgov`) and is not yet publicly launched.

- **LGU Name:** City of Manila, Metro Manila
- **Domain:** [bettermanila.org](https://bettermanila.org)
- **Repository Link:** https://github.com/grgdlm/bettermanila
- **Social Links:** -
- **Status:** Work in Progress
- **Maintainer GitHub Handle/s:** [@grgdlm](https://github.com/grgdlm)

I searched the directory first as the guide asks — Las Piñas and Taguig are listed, but the City of Manila is not, and no open PR claims it. Happy to team up with anyone already working on it.

## Checklist

- [x] I have added/updated the entry in the `README.md` directory table.
- [x] The status badge is correct according to the [Status Legend](README.md#status-legend).
- [x] All blank fields use `-` instead of being left empty.
- [x] All maintainer handles are linked to their GitHub profiles.

Verified the new row parses cleanly with `scripts/sync-to-data.js` (64 entries validated). `CHANGELOG.md` left untouched per CONTRIBUTING.
