### PR TITLE
docs(github): route questions and proposals to Discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,11 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Ask a question
+    url: https://github.com/jmacj/better-lgu-directory/discussions/categories/q-a
+    about: Building a portal? Ask about templates, domains, or public data sources in Q&A.
+  - name: Propose a directory change
+    url: https://github.com/jmacj/better-lgu-directory/discussions/categories/ideas
+    about: Suggest a change to the directory table, badges, or contribution process.
   - name: BetterGov.ph Community
     url: https://bettergov.ph
     about: For general questions, visit the BetterGov.ph community site.


### PR DESCRIPTION
Adds two `contact_links` to the issue chooser pointing at Discussions **Q&A** and **Ideas**.

## Why

`blank_issues_enabled: false`, and the only two issue templates are `update-entry` and `report-inactive`. The single contact link went off-repo to bettergov.ph. So a contributor with a build question ("which template?", "where do I get budget data?", "how do I get a `.org`?") or a proposal for the directory itself had **no inbound path** — Discussions was invisible from the New Issue page.

## Change

```yaml
contact_links:
  - name: Ask a question          # → /discussions/categories/q-a
  - name: Propose a directory change  # → /discussions/categories/ideas
  - name: BetterGov.ph Community  # unchanged, now third
```

Existing bettergov.ph link kept, moved below the two repo-local paths.

## Verification

- Category slugs confirmed against the GraphQL API: `q-a`, `ideas`
- YAML parses; `blank_issues_enabled` and both issue templates untouched

## Notes for reviewer

- **Pairs with the Discussions seed posts** (welcome/routing, Q&A, Show and tell) landing separately — those are Discussions content, not repo files.
- **`CHANGELOG.md` deliberately untouched** per `CONTRIBUTING.md`.
- **Depends on the category prune** — General and Polls are being removed by hand (GitHub exposes no API for category delete). Neither is linked here, so this file is correct either way.