### PR TITLE
feat(data): crawl Featured Portal metadata and schedule daily rotation (#132)

### DIFF
--- a/.github/workflows/rebuild-featured.yml
+++ b/.github/workflows/rebuild-featured.yml
@@ -1,0 +1,32 @@
+name: Daily Featured Portal Rebuild
+
+# Advances the Featured Portal rotation (#132) by requesting a Pages rebuild
+# with zero commits — the build-time Liquid index is a pure function of the
+# current date (#131), so a fresh build is all "today's pick" needs.
+#
+# schedule + workflow_dispatch only. Never `push` on main-pages: that would
+# self-loop with sync-to-pages.yml, which pushes to main-pages on every sync.
+on:
+  schedule:
+    # 16:00 UTC = 00:00 Asia/Manila. The Philippines has no DST (fixed
+    # UTC+8), so this is a stable day boundary with no timezone data needed.
+    - cron: '0 16 * * *'
+  workflow_dispatch: {}
+
+# Shared with sync-to-pages.yml (#132) so a same-time crawl commit and this
+# no-commit rebuild request can't race each other.
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: false
+
+permissions:
+  pages: write
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request a Pages rebuild (no commit)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh api --method POST "repos/${{ github.repository }}/pages/builds"

--- a/.github/workflows/sync-to-pages.yml
+++ b/.github/workflows/sync-to-pages.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - main
 
+# Shared with rebuild-featured.yml (#132) so a same-time crawl commit and a
+# no-commit Pages rebuild request can't race each other.
+concurrency:
+  group: pages-deploy
+  cancel-in-progress: false
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -33,6 +39,10 @@ jobs:
       - name: Generate LGU Data
         run: |
           node scripts/sync-to-data.js
+
+      - name: Generate Featured Portal Metadata
+        run: |
+          node scripts/crawl-lgu-meta.js
 
       - name: Commit and Push to main-pages
         run: |

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -25,5 +25,5 @@ The social network a Social points to (facebook, x, instagram, linkedin, youtube
 _Avoid_: network, provider, site.
 
 **Sync pipeline**:
-The `main` → `main-pages` projection: `scripts/sync-to-data.js` parses the `README.md` table into `_data/lgus.yml`, which `index.md` renders. `README.md` is the source of truth; `_data/lgus.yml` is generated and never hand-edited.
+The `main` → `main-pages` projection, run by `sync-to-pages.yml` on every push to `main`. It generates two files, both written into the same `chore(data): auto-sync` commit and never hand-edited: `scripts/sync-to-data.js` parses the `README.md` table into `_data/lgus.yml`, which `index.md` renders as the directory table; `scripts/crawl-lgu-meta.js` crawls each `🟢 Active` Entry's portal and writes `_data/lgu-meta.yml` (image, title, description, domain, and a stable `order_key`) for every Entry that passes the Featured Portal eligibility predicate, which the hero's Featured card partial reads. `README.md` remains the sole source of truth for Entries; both generated files are derived data.
 _Avoid_: build, import.

--- a/scripts/crawl-lgu-meta.js
+++ b/scripts/crawl-lgu-meta.js
@@ -1,0 +1,435 @@
+const fs = require('fs');
+const path = require('path');
+const http = require('http');
+const https = require('https');
+const crypto = require('crypto');
+const { README_PATH, parseTable, validateLgu } = require('./sync-to-data.js');
+
+const LGU_META_PATH = process.argv[2] || path.join(__dirname, '../_data/lgu-meta.yml');
+
+const USER_AGENT = 'BetterLGUDirectoryBot/1.0 (+https://lgu.bettergov.ph)';
+const REQUEST_TIMEOUT_MS = 10_000;
+const MAX_REDIRECTS = 5;
+const IMAGE_SIZE_CEILING_BYTES = 400 * 1024; // #127: 400KB ceiling, checked on fetched bytes
+
+// #122: the crawl excludes any Entry whose resolved title/description is
+// byte-identical (whitespace-normalised) to BetterGov.ph's generic template
+// copy — a portal can be mechanically complete yet still not be "about" the
+// LGU. Kept in one place so a future template revision is a one-line change.
+const BOILERPLATE_DESCRIPTION =
+    'Community-powered portal of the Republic of the Philippines. Access government services, stay updated with the latest news, and find information about the Philippines.';
+const BOILERPLATE_TITLE =
+    'BetterGov.ph | Republic of the Philippines | Community Powered Government Portal';
+
+function normalizeWhitespace(value) {
+    return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function isBoilerplate(title, description) {
+    const normDescription = normalizeWhitespace(description);
+    const normTitle = normalizeWhitespace(title);
+    return (
+        normDescription === normalizeWhitespace(BOILERPLATE_DESCRIPTION) ||
+        normTitle === normalizeWhitespace(BOILERPLATE_TITLE)
+    );
+}
+
+// Escape a value for safe embedding inside a double-quoted YAML scalar.
+function yamlStr(value) {
+    return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
+function sha1First8(value) {
+    return crypto.createHash('sha1').update(value).digest('hex').slice(0, 8);
+}
+
+// Marker used internally to distinguish "the portal looked down" (network
+// error, timeout, non-2xx/3xx on the page itself) from "the portal answered
+// but the metadata isn't good enough" (missing/oversized image, boilerplate
+// copy, robots disallow). Only the former preserves the previous row — see
+// the catch block in main() below and issue #132's failure-tolerance
+// requirement.
+class PortalUnreachableError extends Error {}
+
+function requestOnce(urlString, { method = 'GET', maxBytes } = {}) {
+    return new Promise((resolve, reject) => {
+        let url;
+        try {
+            url = new URL(urlString);
+        } catch (err) {
+            reject(new PortalUnreachableError(`Invalid URL: ${urlString}`));
+            return;
+        }
+
+        const lib = url.protocol === 'http:' ? http : https;
+        const req = lib.request(
+            url,
+            {
+                method,
+                headers: { 'User-Agent': USER_AGENT },
+                timeout: REQUEST_TIMEOUT_MS,
+            },
+            (res) => {
+                const chunks = [];
+                let total = 0;
+                let aborted = false;
+
+                res.on('data', (chunk) => {
+                    if (aborted) return;
+                    total += chunk.length;
+                    if (maxBytes && total > maxBytes) {
+                        aborted = true;
+                        res.destroy();
+                        resolve({
+                            statusCode: res.statusCode,
+                            headers: res.headers,
+                            body: Buffer.concat(chunks),
+                            truncatedOversize: true,
+                        });
+                        return;
+                    }
+                    chunks.push(chunk);
+                });
+                res.on('end', () => {
+                    if (aborted) return;
+                    resolve({
+                        statusCode: res.statusCode,
+                        headers: res.headers,
+                        body: Buffer.concat(chunks),
+                        truncatedOversize: false,
+                    });
+                });
+                res.on('error', (err) => reject(new PortalUnreachableError(err.message)));
+            },
+        );
+
+        req.on('timeout', () => {
+            req.destroy(new PortalUnreachableError(`Timed out fetching ${urlString}`));
+        });
+        req.on('error', (err) => reject(new PortalUnreachableError(err.message)));
+        req.end();
+    });
+}
+
+// Follows redirects manually (Node's http/https do not) so we can keep
+// enforcing our own timeout and User-Agent on every hop.
+async function fetchFollowingRedirects(urlString, opts = {}) {
+    let currentUrl = urlString;
+    for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+        const res = await requestOnce(currentUrl, opts);
+        if ([301, 302, 303, 307, 308].includes(res.statusCode) && res.headers.location) {
+            currentUrl = new URL(res.headers.location, currentUrl).toString();
+            continue;
+        }
+        return { ...res, finalUrl: currentUrl };
+    }
+    throw new PortalUnreachableError(`Too many redirects fetching ${urlString}`);
+}
+
+// Minimal hand-rolled robots.txt check (#128) — deliberately not a full RFC
+// parser: we fetch exactly one page per site, so path-level rule matching
+// buys nothing, and a library would be this repo's first npm dependency.
+// Looks only for a blanket "Disallow: /" in the "*" group or a group naming
+// our UA, and reads any Crawl-delay set for either.
+async function checkRobots(origin) {
+    let body;
+    try {
+        const res = await fetchFollowingRedirects(new URL('/robots.txt', origin).toString());
+        if (res.statusCode >= 400) {
+            return { disallowed: false, crawlDelaySeconds: 0 };
+        }
+        body = res.body.toString('utf8');
+    } catch {
+        // No robots.txt (or it's unreachable) is not itself a reason to skip —
+        // absence of the file means no rules apply.
+        return { disallowed: false, crawlDelaySeconds: 0 };
+    }
+
+    const ourUaLower = 'betterlgudirectorybot';
+    let currentAgents = [];
+    let groupJustStarted = false;
+    let disallowed = false;
+    let crawlDelaySeconds = 0;
+
+    for (const rawLine of body.split(/\r?\n/)) {
+        const line = rawLine.replace(/#.*$/, '').trim();
+        if (!line) continue;
+        const [rawKey, ...rest] = line.split(':');
+        if (!rawKey || rest.length === 0) continue;
+        const key = rawKey.trim().toLowerCase();
+        const value = rest.join(':').trim();
+
+        if (key === 'user-agent') {
+            if (!groupJustStarted) currentAgents = [];
+            currentAgents.push(value.toLowerCase());
+            groupJustStarted = true;
+            continue;
+        }
+
+        groupJustStarted = false;
+        const appliesToUs = currentAgents.includes('*') || currentAgents.includes(ourUaLower);
+        if (!appliesToUs) continue;
+
+        if (key === 'disallow' && value === '/') {
+            disallowed = true;
+        } else if (key === 'crawl-delay') {
+            const seconds = Number(value);
+            if (Number.isFinite(seconds) && seconds > crawlDelaySeconds) {
+                crawlDelaySeconds = seconds;
+            }
+        }
+    }
+
+    return { disallowed, crawlDelaySeconds };
+}
+
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+// Attribute parsing shared by title/meta extraction — deliberately regex
+// based rather than a DOM parser, matching this repo's zero-dependency rule.
+function parseTagAttrs(tagSource) {
+    const attrs = {};
+    const attrPattern = /([a-zA-Z][\w:-]*)\s*=\s*("([^"]*)"|'([^']*)')/g;
+    let match;
+    while ((match = attrPattern.exec(tagSource)) !== null) {
+        const name = match[1].toLowerCase();
+        const value = match[3] !== undefined ? match[3] : match[4];
+        attrs[name] = value;
+    }
+    return attrs;
+}
+
+function decodeHtmlEntities(value) {
+    return String(value)
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#0?39;/g, "'");
+}
+
+function extractMeta(html) {
+    const metaTags = html.match(/<meta\s+[^>]*>/gi) || [];
+    const meta = {};
+    for (const tag of metaTags) {
+        const attrs = parseTagAttrs(tag);
+        const key = (attrs.property || attrs.name || '').toLowerCase();
+        if (key && attrs.content !== undefined) {
+            meta[key] = attrs.content;
+        }
+    }
+
+    const titleMatch = html.match(/<title[^>]*>([\s\S]*?)<\/title>/i);
+    const documentTitle = titleMatch ? decodeHtmlEntities(titleMatch[1]).trim() : '';
+
+    // #122: title resolves og:title falling back to <title>; description
+    // resolves og:description falling back to <meta name="description">;
+    // the image has no fallback source — og:image only.
+    const title = decodeHtmlEntities(meta['og:title'] || documentTitle || '').trim();
+    const description = decodeHtmlEntities(meta['og:description'] || meta['description'] || '').trim();
+    const image = (meta['og:image'] || '').trim();
+
+    return { title, description, image };
+}
+
+// README domain cells are markdown links — e.g. "[bettersolano.org]
+// (https://bettersolano.org)" — the same raw form validateLgu() stores
+// (sync-to-data.js relies on kramdown re-processing that text at render
+// time; see index.md's `markdown="1"` table wrapper). Extract the real URL
+// to crawl and the bare hostname to display, falling back to treating the
+// whole cell as a bare hostname if it isn't a markdown link.
+function extractDomainLink(rawCell) {
+    const match = /\[([^\]]+)\]\(([^)]+)\)/.exec(rawCell || '');
+    if (match) {
+        return { label: match[1].trim(), url: match[2].trim() };
+    }
+    const bare = String(rawCell || '').trim();
+    return { label: bare, url: /^https?:\/\//i.test(bare) ? bare : `https://${bare}` };
+}
+
+// Crawls one Entry's portal and returns a complete lgu-meta row, or null if
+// the portal is reachable but does not meet the completeness/quality bar
+// (#122, #125, #127). Throws PortalUnreachableError if the portal itself
+// looks down — callers use that to decide whether to preserve the previous
+// row instead of dropping it.
+async function crawlEntry(entry, displayDomain, origin) {
+    const robots = await checkRobots(origin);
+    if (robots.disallowed) {
+        return null;
+    }
+    if (robots.crawlDelaySeconds > 0) {
+        await sleep(robots.crawlDelaySeconds * 1000);
+    }
+
+    const pageRes = await fetchFollowingRedirects(origin);
+    if (pageRes.statusCode >= 400 || pageRes.statusCode < 200) {
+        throw new PortalUnreachableError(`${displayDomain} returned HTTP ${pageRes.statusCode}`);
+    }
+
+    const contentType = (pageRes.headers['content-type'] || '').toLowerCase();
+    if (contentType && !contentType.includes('html')) {
+        throw new PortalUnreachableError(`${displayDomain} did not return HTML (${contentType})`);
+    }
+
+    const html = pageRes.body.toString('utf8');
+    const { title, description, image } = extractMeta(html);
+
+    if (!title || !description || !image) {
+        // Mechanically incomplete — no fallback (#125), no row.
+        return null;
+    }
+
+    if (isBoilerplate(title, description)) {
+        // Complete but not "about" the LGU (#122's quality floor) — no row.
+        return null;
+    }
+
+    if (robots.crawlDelaySeconds > 0) {
+        await sleep(robots.crawlDelaySeconds * 1000);
+    }
+
+    const imageUrl = new URL(image, pageRes.finalUrl).toString();
+    let imageRes;
+    try {
+        imageRes = await fetchFollowingRedirects(imageUrl, { maxBytes: IMAGE_SIZE_CEILING_BYTES });
+    } catch (err) {
+        // The image failing to load is a metadata-quality problem, not the
+        // whole portal being down — the page itself answered fine.
+        return null;
+    }
+
+    if (imageRes.statusCode >= 400 || imageRes.statusCode < 200) {
+        return null;
+    }
+    const imageContentType = (imageRes.headers['content-type'] || '').toLowerCase();
+    if (!imageContentType.startsWith('image/')) {
+        return null;
+    }
+    if (imageRes.truncatedOversize || imageRes.body.length > IMAGE_SIZE_CEILING_BYTES) {
+        return null;
+    }
+
+    return {
+        name: entry.name,
+        domain: displayDomain,
+        image: imageUrl,
+        title,
+        description,
+        order_key: sha1First8(displayDomain),
+    };
+}
+
+function parseExistingLguMeta(filePath) {
+    // Reads the previously-generated _data/lgu-meta.yml, if any, so an
+    // unreachable-this-run portal can keep its last-known-good row (#132:
+    // "a portal that's down leaves its previous row untouched"). Hand-rolled
+    // reader matching the hand-rolled writer below — this file's schema is
+    // simple and fixed, so a YAML library is not worth adding. Keyed by the
+    // clean display domain (not the README's raw markdown cell).
+    if (!fs.existsSync(filePath)) return new Map();
+
+    const content = fs.readFileSync(filePath, 'utf8');
+    const byDomain = new Map();
+    const entryBlocks = content.split(/\n(?=- name:)/);
+
+    for (const block of entryBlocks) {
+        if (!block.trim().startsWith('- name:')) continue;
+        const get = (key) => {
+            const m = block.match(new RegExp(`${key}:\\s*"((?:[^"\\\\]|\\\\.)*)"`));
+            return m ? m[1].replace(/\\"/g, '"').replace(/\\\\/g, '\\') : '';
+        };
+        const domain = get('domain');
+        if (!domain) continue;
+        byDomain.set(domain, {
+            name: get('name'),
+            domain,
+            image: get('image'),
+            title: get('title'),
+            description: get('description'),
+            order_key: get('order_key'),
+        });
+    }
+    return byDomain;
+}
+
+function formatLguMetaYaml(rows) {
+    if (rows.length === 0) return '';
+    return rows
+        .map((row) =>
+            [
+                `- name: "${yamlStr(row.name)}"`,
+                `  domain: "${yamlStr(row.domain)}"`,
+                `  image: "${yamlStr(row.image)}"`,
+                `  title: "${yamlStr(row.title)}"`,
+                `  description: "${yamlStr(row.description)}"`,
+                `  order_key: "${yamlStr(row.order_key)}"`,
+            ].join('\n'),
+        )
+        .join('\n');
+}
+
+async function main() {
+    console.log('🚀 Starting Featured Portal metadata crawl...');
+    const readmeContent = fs.readFileSync(README_PATH, 'utf8');
+    const rawLgus = parseTable(readmeContent, '<!-- SYNC_LGU_TABLE_START -->', '<!-- SYNC_LGU_TABLE_END -->');
+    const lgus = rawLgus.map(validateLgu);
+
+    // #122: eligibility gate #1 — status must be Active. Domain is required
+    // by construction: no domain means nothing to crawl, so such an Entry can
+    // never satisfy the completeness gate.
+    const candidates = lgus.filter((lgu) => lgu.status === '🟢 Active' && lgu.domain && lgu.domain !== '-');
+
+    const previous = parseExistingLguMeta(LGU_META_PATH);
+    const rows = [];
+
+    for (const entry of candidates) {
+        const { label: displayDomain, url: origin } = extractDomainLink(entry.domain);
+        try {
+            const row = await crawlEntry(entry, displayDomain, origin);
+            if (row) {
+                rows.push(row);
+                console.log(`  ✅ ${displayDomain} — featured row generated`);
+            } else {
+                console.log(`  ⛔ ${displayDomain} — ineligible (incomplete, boilerplate, or robots-disallowed)`);
+            }
+        } catch (err) {
+            if (err instanceof PortalUnreachableError && previous.has(displayDomain)) {
+                rows.push(previous.get(displayDomain));
+                console.log(`  ⚠️  ${displayDomain} — unreachable this run (${err.message}); kept previous row`);
+            } else {
+                console.log(`  ⛔ ${displayDomain} — unreachable and no previous row (${err.message})`);
+            }
+        }
+    }
+
+    const dataDir = path.dirname(LGU_META_PATH);
+    if (!fs.existsSync(dataDir)) {
+        fs.mkdirSync(dataDir, { recursive: true });
+    }
+    fs.writeFileSync(LGU_META_PATH, formatLguMetaYaml(rows));
+    console.log(`🎉 Featured pool: ${rows.length} eligible portal(s). Written to ${LGU_META_PATH}`);
+}
+
+if (require.main === module) {
+    main().catch((err) => {
+        console.error(`\n❌ CRAWL FAILED: ${err.stack || err.message}`);
+        process.exit(1);
+    });
+}
+
+module.exports = {
+    USER_AGENT,
+    IMAGE_SIZE_CEILING_BYTES,
+    BOILERPLATE_DESCRIPTION,
+    BOILERPLATE_TITLE,
+    normalizeWhitespace,
+    isBoilerplate,
+    sha1First8,
+    extractMeta,
+    parseTagAttrs,
+    extractDomainLink,
+    parseExistingLguMeta,
+    formatLguMetaYaml,
+};

--- a/scripts/test-rotation-index.js
+++ b/scripts/test-rotation-index.js
@@ -1,0 +1,212 @@
+// Zero-dependency regression test for the Featured Portal rotation index
+// (#131) and the crawl helpers in crawl-lgu-meta.js (#122, #125, #127, #128).
+// This repo has no package.json / test runner on either branch, so this is a
+// plain Node script using the built-in `assert` module. Run with:
+//
+//   node scripts/test-rotation-index.js
+//
+// It exits non-zero on any failure, so it can be wired into CI later without
+// change if this repo ever adopts one.
+//
+// Why this exists: #131's resolution flagged that the exact Liquid filter
+// chain (`site.time | date: '%s' | times: 1 | divided_by: 86400 | modulo:
+// pool.size`) was never run against a live Jekyll build while the design was
+// being decided, and asked for it to be "verified in the implementation and
+// covered by a test." Liquid itself cannot be unit tested outside a Jekyll
+// build, so this test instead re-implements the *documented* filter
+// semantics in plain JS (Unix seconds -> string -> coerced back to a number
+// -> floor-divided by 86400 -> modulo pool size) and proves the properties
+// the design depends on: true round-robin with no repeats inside a cycle,
+// and safe behaviour at the degenerate pool sizes (0 and 1). It is a proof of
+// the arithmetic, not a substitute for eyeballing one real `bundle exec
+// jekyll build` — see the PR notes for that gap.
+
+const assert = require('assert');
+const {
+    isBoilerplate,
+    sha1First8,
+    extractMeta,
+    normalizeWhitespace,
+    extractDomainLink,
+} = require('./crawl-lgu-meta.js');
+
+// --- Liquid filter chain, mirrored in JS -----------------------------------
+//
+// {%- assign pool = site.data.lgu-meta | sort: "order_key" -%}
+// {%- assign day = site.time | date: '%s' | times: 1 | divided_by: 86400 -%}
+// {%- assign i = day | modulo: pool.size -%}
+// {%- assign featured = pool[i] -%}
+//
+// Liquid's `date: '%s'` returns Unix seconds as a *string*; `times: 1`
+// coerces it to a number; `divided_by` on two integers performs integer
+// (floor) division. `modulo` follows Ruby's `%`, which for two non-negative
+// operands (always true here — Unix seconds and pool.size are never
+// negative) agrees with JS's `%`.
+function sortByOrderKey(pool) {
+    return [...pool].sort((a, b) => (a.order_key < b.order_key ? -1 : a.order_key > b.order_key ? 1 : 0));
+}
+
+function dayNumber(unixSeconds) {
+    const asString = String(unixSeconds); // date: '%s'
+    const asNumber = Number(asString); // times: 1
+    return Math.floor(asNumber / 86400); // divided_by: 86400 (integer division)
+}
+
+function pickFeatured(pool, unixSeconds) {
+    const sorted = sortByOrderKey(pool);
+    if (sorted.length === 0) return null; // #131/#125: empty pool renders nothing
+    const day = dayNumber(unixSeconds);
+    const i = day % sorted.length;
+    return sorted[i];
+}
+
+function makePool(size) {
+    return Array.from({ length: size }, (_, n) => ({
+        domain: `lgu-${n}.example.gov.ph`,
+        order_key: sha1First8(`lgu-${n}.example.gov.ph`),
+    }));
+}
+
+let assertions = 0;
+function check(condition, message) {
+    assertions++;
+    assert.ok(condition, message);
+}
+
+// --- day number arithmetic --------------------------------------------------
+
+// 2026-08-01T16:00:00Z, the scheduled rebuild's own fixed cron moment.
+const KNOWN_UNIX_SECONDS = 1785600000;
+check(dayNumber(KNOWN_UNIX_SECONDS) === 20666, 'dayNumber floors Unix seconds to a whole day count');
+check(dayNumber(0) === 0, 'dayNumber(epoch) is day 0');
+check(dayNumber(86399) === 0, 'dayNumber stays on day 0 for the last second before the boundary');
+check(dayNumber(86400) === 1, 'dayNumber advances exactly at the 86400s boundary');
+
+// --- degenerate pool sizes ---------------------------------------------------
+
+check(pickFeatured([], KNOWN_UNIX_SECONDS) === null, 'an empty pool renders nothing (no divide-by-zero)');
+
+const poolOfOne = makePool(1);
+for (let d = 0; d < 10; d++) {
+    const featured = pickFeatured(poolOfOne, d * 86400);
+    check(featured.domain === poolOfOne[0].domain, 'a pool of 1 always picks the same (only) entry');
+}
+
+// --- true round-robin, no repeats inside a cycle ----------------------------
+
+for (const size of [2, 3, 6, 7, 20]) {
+    const pool = makePool(size);
+    const sorted = sortByOrderKey(pool);
+
+    // One full cycle: every member appears exactly once.
+    const seenInCycle = new Set();
+    for (let d = 0; d < size; d++) {
+        const featured = pickFeatured(pool, d * 86400);
+        check(!seenInCycle.has(featured.domain), `pool size ${size}: no repeat within one ${size}-day cycle (day ${d})`);
+        seenInCycle.add(featured.domain);
+    }
+    check(seenInCycle.size === size, `pool size ${size}: every member was featured exactly once in one cycle`);
+
+    // The cycle repeats identically afterwards (stateless, pure function of the date).
+    for (let d = 0; d < size; d++) {
+        const first = pickFeatured(pool, d * 86400);
+        const second = pickFeatured(pool, (d + size) * 86400);
+        check(first.domain === second.domain, `pool size ${size}: cycle ${d} repeats identically on day ${d + size}`);
+    }
+
+    // Consecutive days walk the sorted pool in lockstep (index increments by 1 mod size).
+    for (let d = 0; d < size * 2; d++) {
+        const featured = pickFeatured(pool, d * 86400);
+        check(featured.domain === sorted[d % size].domain, `pool size ${size}: day ${d} matches sorted[${d % size}]`);
+    }
+}
+
+// Two builds landing on the same day (e.g. a push-triggered sync at noon and
+// the 16:00 UTC scheduled rebuild) must render the same LGU.
+{
+    const pool = makePool(6);
+    const morning = pickFeatured(pool, Date.UTC(2026, 7, 1, 2, 0, 0) / 1000);
+    const evening = pickFeatured(pool, Date.UTC(2026, 7, 1, 23, 0, 0) / 1000);
+    check(morning.domain === evening.domain, 'two builds on the same UTC day pick the same featured entry');
+}
+
+// --- order_key (#131) --------------------------------------------------------
+
+check(/^[0-9a-f]{8}$/.test(sha1First8('example.gov.ph')), 'order_key is 8 lowercase hex characters');
+check(sha1First8('example.gov.ph') === sha1First8('example.gov.ph'), 'order_key is stable for the same domain');
+check(sha1First8('example.gov.ph') !== sha1First8('another.gov.ph'), 'different domains produce different order_keys (expected, not guaranteed)');
+
+// --- eligibility quality floor (#122) ---------------------------------------
+
+check(
+    isBoilerplate(
+        'BetterGov.ph | Republic of the Philippines | Community Powered Government Portal',
+        'Some custom description',
+    ),
+    'exact-match boilerplate title alone disqualifies the entry',
+);
+check(
+    isBoilerplate(
+        'BetterDasmariñas.org | Transparency Portal Portal',
+        'Community-powered portal of the Republic of the Philippines. Access government services, stay updated with the latest news, and find information about the Philippines.',
+    ),
+    'a customised title with the boilerplate description still disqualifies the entry (description is the primary check)',
+);
+check(
+    !isBoilerplate('BetterExample Portal', 'A portal built by the Example LGU community.'),
+    'genuinely custom title/description is not treated as boilerplate',
+);
+check(
+    normalizeWhitespace('  a  b\n c ') === 'a b c',
+    'normalizeWhitespace collapses and trims whitespace before comparison',
+);
+
+// --- meta extraction (#122's og:* -> fallback rule) -------------------------
+
+{
+    const html = `<html><head>
+      <title>Fallback Document Title</title>
+      <meta name="description" content="Fallback meta description.">
+      <meta property="og:image" content="/banner.jpg">
+      </head><body></body></html>`;
+    const meta = extractMeta(html);
+    check(meta.title === 'Fallback Document Title', 'title falls back to <title> when og:title is absent');
+    check(meta.description === 'Fallback meta description.', 'description falls back to meta[name=description] when og:description is absent');
+    check(meta.image === '/banner.jpg', 'image is read from og:image with no fallback source');
+}
+{
+    const html = `<html><head>
+      <title>Document Title</title>
+      <meta property="og:title" content="OG Title Wins">
+      <meta name="description" content="Doc description">
+      <meta property="og:description" content="OG description wins">
+      </head></html>`;
+    const meta = extractMeta(html);
+    check(meta.title === 'OG Title Wins', 'og:title takes priority over <title> when both are present');
+    check(meta.description === 'OG description wins', 'og:description takes priority over meta[name=description] when both are present');
+}
+{
+    // Attribute order varies across sites (content before property/name).
+    const html = `<meta content="Reordered description" name="description">`;
+    const meta = extractMeta(html);
+    check(meta.description === 'Reordered description', 'meta attribute parsing is order-independent');
+}
+
+// --- README domain-cell parsing (#132: cells hold raw markdown links) ------
+
+{
+    const link = extractDomainLink('[bettersolano.org](https://bettersolano.org)');
+    check(link.label === 'bettersolano.org', 'extractDomainLink reads the markdown link label as the display domain');
+    check(link.url === 'https://bettersolano.org', 'extractDomainLink reads the markdown link URL as the crawl target');
+}
+{
+    const link = extractDomainLink('example.gov.ph');
+    check(link.label === 'example.gov.ph', 'extractDomainLink falls back to the bare cell as the display domain');
+    check(link.url === 'https://example.gov.ph', 'extractDomainLink defaults a bare hostname to https://');
+}
+{
+    const link = extractDomainLink('https://already-a-url.gov.ph');
+    check(link.url === 'https://already-a-url.gov.ph', 'extractDomainLink does not double-prefix a bare cell that already has a scheme');
+}
+
+console.log(`✅ ${assertions} assertions passed.`);


### PR DESCRIPTION
## Summary

Part 1 of 2 for #132 (Implement Featured Portal). This PR covers the pieces that live on `main`: the metadata crawl and the daily rebuild schedule. Part 2 (the hero card + CSS on `main-pages`) is #135.

- Extends `sync-to-pages.yml` with a `Generate Featured Portal Metadata` step (`scripts/crawl-lgu-meta.js`) that crawls every `🟢 Active` Entry with a domain and writes `_data/lgu-meta.yml` (name, domain, image, title, description, order_key). Staged into the same `chore(data): auto-sync` commit — no new commit path (`git add _data/` already covers both generated files).
- Eligibility predicate per #122/#125/#127: portal reachable, `og:image` fetched and verified (status + `image/*` content-type + ≤400KB on fetched bytes), title (`og:title` → `<title>`) and description (`og:description` → `meta[name=description]`) both resolved, and neither exact-matches (whitespace-normalised) BetterGov.ph's known template boilerplate strings.
- UA `BetterLGUDirectoryBot/1.0 (+https://lgu.bettergov.ph)`, hand-rolled `robots.txt` check (blanket `Disallow: /` in the `*` group or a group naming our UA) and `Crawl-delay` honouring, zero new dependencies (repo has no `package.json` on either branch).
- Failure-tolerant: a portal that's unreachable *this run* (network error, timeout, non-2xx page response) keeps its previous `_data/lgu-meta.yml` row instead of dropping out. A reachable-but-ineligible portal (incomplete metadata, boilerplate copy, oversized/broken image, robots-disallowed) is treated as a normal drop, same as today — see "Notes for reviewer" below.
- New `.github/workflows/rebuild-featured.yml`: `schedule` (`0 16 * * *` = 16:00 UTC = 00:00 Asia/Manila) + `workflow_dispatch` only, POSTs to `/repos/{owner}/{repo}/pages/builds` to request a no-commit rebuild that advances the build-time rotation. Shares a `concurrency: pages-deploy` group with `sync-to-pages.yml` (added to both).
- `CONTEXT.md`'s "Sync pipeline" glossary entry now describes both generated files.
- `scripts/test-rotation-index.js`: a dependency-free assertion script (this repo has no test runner) proving the rotation arithmetic — true round-robin with no repeats inside a cycle, degenerate pool sizes (0 and 1), two same-day builds picking the same LGU — plus regression coverage for the crawl helpers (boilerplate check, og:* fallback resolution, README markdown-link domain parsing). Run with `node scripts/test-rotation-index.js`.

## Acceptance criteria (this PR's share)

- [x] `sync-to-pages.yml` writes `_data/lgu-meta.yml` with a row only for Entries satisfying the full eligibility predicate; no additional commit is created; a no-op crawl produces no commit
- [x] The crawl uses UA `BetterLGUDirectoryBot/1.0 (+https://lgu.bettergov.ph)`, respects blanket `Disallow: /`, and honors `Crawl-delay`
- [x] An unreachable portal leaves its previous row intact rather than removing it
- [x] The rotation index is a pure function of `_data/lgu-meta.yml` and the current date — verified with a test covering at least one full pool cycle with no repeats
- [x] A new scheduled workflow requests a Pages rebuild daily at 16:00 UTC via `workflow_dispatch`-and-`schedule` only, produces no commit, and shares a `concurrency` group with `sync-to-pages.yml`
- [x] `CONTEXT.md`'s "Sync pipeline" entry is updated to describe both generated files
- [ ] Card rendering / hero AC items — covered by the companion `main-pages` PR (#135), not this one

## Notes for reviewer

- **CHANGELOG.md**: this repo's own file says "Contributors are requested to **not** update the `CHANGELOG.md` in their Pull Requests" — skipped per that instruction (the sf1 workflow's default is to update it, but the repo's explicit convention overrides).
- **Judgment call — "unreachable" vs "ineligible."** The issue text says "a portal that's down leaves its previous row untouched," but doesn't define "down" precisely. I drew the line at network-level failure of the *main page fetch* (connection error, timeout, non-2xx/non-3xx status, non-HTML response) → keep the previous row. Everything else that's a *reachable* portal failing a quality gate (robots disallow, missing/oversized/wrong-type image, incomplete title/description, boilerplate copy) → treated as a normal drop, consistent with #125/#127's "self-healing in both directions" framing. Flagging in case the intent was broader.
- **Schema deviation from the issue text.** The issue lists `_data/lgu-meta.yml`'s fields as "image URL, title, description, domain, order_key." I added a `name` field (the LGU's directory name) as a join key so the hero card (companion PR) can look up `maintainer`/`socials` from `_data/lgus.yml` without matching on the markdown-wrapped `domain` cell (see next note). It's additive and doesn't change any of the specified fields.
- **README domain cells are markdown links, not bare hostnames** — e.g. `[bettersolano.org](https://bettersolano.org)` — which is also what `scripts/sync-to-data.js` stores verbatim in `_data/lgus.yml` (it relies on `index.md`'s `markdown="1"` table wrapper to re-render it). `crawl-lgu-meta.js` has to parse that markdown link to get both the actual URL to crawl and the bare hostname to display/hash; see `extractDomainLink()`.
- **Could not run a real crawl or a live Jekyll build in this environment** (no verified network egress to the ~20 portal domains, and no `ruby`/`bundler` installed). Verified instead via: `node --check` on both scripts, the full `test-rotation-index.js` assertion suite (191 assertions), and manual YAML round-trip tests of the reader/writer (including quote/backslash escaping). Recommend a `workflow_dispatch` run of `sync-to-pages.yml` right after merge to get a first real `_data/lgu-meta.yml`, then a manual Pages rebuild to sanity-check the card renders — flagging this as the one gap in this PR's own verification.

Closes part of #132 (see #135 for the rest).
