### PR TITLE
feat(site): render the Featured Portal card in the hero (#132)

### DIFF
--- a/_includes/featured-portal.html
+++ b/_includes/featured-portal.html
@@ -49,7 +49,8 @@ emits from `lgu.maintainer`'s raw markdown).
 
     <div class="relative z-0 aspect-[1200/630] w-full overflow-hidden">
       {%- comment -%} Decorative — the eyebrow and heading below already carry the same information as real text (#133). {%- endcomment -%}
-      <img src="{{ featured.image }}" alt="" loading="lazy" class="w-full h-full object-cover">
+      {%- comment -%} No loading="lazy": this card sits above the fold (#126/#129 — the hero image is the likely LCP element, and lazy-loading it above the fold would delay first paint). {%- endcomment -%}
+      <img src="{{ featured.image }}" alt="" class="w-full h-full object-cover">
     </div>
 
     <div class="relative z-10 p-6 md:p-8 space-y-3">

--- a/_includes/featured-portal.html
+++ b/_includes/featured-portal.html
@@ -1,0 +1,86 @@
+{%- comment -%}
+Featured Portal card (#132). Pure build-time Liquid — no JavaScript.
+
+Pool: every complete, eligible row in `_data/lgu-meta.yml` (written by the
+crawl in `scripts/crawl-lgu-meta.js` on `main`; see #122/#125 for the
+eligibility predicate). Sorted by the crawl-assigned `order_key` (first 8 hex
+chars of sha1(domain)) so the sequence is shuffled but stable per portal, not
+alphabetical (#131).
+
+Index: the Unix day number modulo the pool size — a pure function of the
+build's own clock, re-evaluated once a day by the scheduled rebuild in
+`.github/workflows/rebuild-featured.yml`. `date: '%s'` returns a string, so it
+is coerced with `times: 1` before the integer division — see
+scripts/test-rotation-index.js for the arithmetic proof (#131 flagged this
+chain as unverified against a live Jekyll build; verify it here on first
+deploy).
+
+If the pool is empty, this include renders nothing — no divide-by-zero, no
+placeholder card (#125's no-fallback rule extends to the degenerate case).
+
+Layout: a themed (blue-on-glass) variant of the same glassmorphism the panel
+it replaces used — see the `.featured-portal-*` rules in assets/css/style.css
+for the parts Tailwind's utility classes can't express cleanly (the inverted
+badge pill, the stretched-link overlay, and styling the `<a>` tags kramdown
+emits from `lgu.maintainer`'s raw markdown).
+{%- endcomment -%}
+{%- assign pool = site.data.lgu-meta | sort: "order_key" -%}
+{%- if pool and pool.size > 0 -%}
+  {%- assign day = site.time | date: '%s' | times: 1 | divided_by: 86400 -%}
+  {%- assign i = day | modulo: pool.size -%}
+  {%- assign featured = pool[i] -%}
+  {%- assign lgu = site.data.lgus | where: "name", featured.name | first -%}
+  {%- comment -%}
+  The whole card is inert to pointer events by default (pointer-events-none);
+  only the stretched link and the individually-marked inline links opt back
+  in with pointer-events-auto. That is what lets the stretched link receive
+  clicks everywhere — including over the image — while the domain,
+  maintainer, and social links stay independently clickable on top of it,
+  without a manual z-index fight between siblings.
+  {%- endcomment -%}
+  <div class="featured-portal-card relative bg-white/10 backdrop-blur-md border border-white/20 rounded-2xl shadow-2xl overflow-hidden pointer-events-none">
+    <a
+      href="https://{{ featured.domain }}"
+      class="featured-portal-card__link absolute inset-0 z-0 rounded-2xl pointer-events-auto"
+      target="_blank"
+      rel="noopener noreferrer"
+      aria-label="Visit {{ featured.name }}'s Better LGU portal"
+    ></a>
+
+    <div class="relative z-0 aspect-[1200/630] w-full overflow-hidden">
+      {%- comment -%} Decorative — the eyebrow and heading below already carry the same information as real text (#133). {%- endcomment -%}
+      <img src="{{ featured.image }}" alt="" loading="lazy" class="w-full h-full object-cover">
+    </div>
+
+    <div class="relative z-10 p-6 md:p-8 space-y-3">
+      <span class="featured-portal-badge">⭐ Featured</span>
+
+      <p class="text-xs font-semibold uppercase tracking-wide text-blue-200">{{ featured.title }}</p>
+      <h2 class="text-2xl font-bold text-white leading-tight">{{ featured.name }}</h2>
+      <p class="text-sm text-blue-100 line-clamp-3">{{ featured.description }}</p>
+
+      <div class="flex flex-wrap items-center gap-x-4 gap-y-2 pt-1">
+        <a
+          href="https://{{ featured.domain }}"
+          class="featured-portal-card__inline-link pointer-events-auto"
+          target="_blank"
+          rel="noopener noreferrer"
+        >{{ featured.domain }}</a>
+
+        {%- if lgu and lgu.maintainer and lgu.maintainer != "-" -%}
+          <span class="featured-portal-card__maintainer pointer-events-auto text-sm text-blue-100">
+            Maintained by {{ lgu.maintainer | markdownify | remove: "<p>" | remove: "</p>" | strip }}
+          </span>
+        {%- endif -%}
+
+        {%- if lgu and lgu.socials and lgu.socials.size > 0 -%}
+          <span class="featured-portal-card__socials pointer-events-auto inline-flex items-center gap-3">
+            {%- for s in lgu.socials -%}
+              {% include social-icon.html label=s.label url=s.url %}
+            {%- endfor -%}
+          </span>
+        {%- endif -%}
+      </div>
+    </div>
+  </div>
+{%- endif -%}

--- a/_includes/featured-portal.html
+++ b/_includes/featured-portal.html
@@ -56,7 +56,7 @@ emits from `lgu.maintainer`'s raw markdown).
     <div class="relative z-10 p-6 md:p-8 space-y-3">
       <span class="featured-portal-badge">⭐ Featured</span>
 
-      <p class="text-xs font-semibold uppercase tracking-wide text-blue-200">{{ featured.title }}</p>
+      <p class="text-xs font-semibold uppercase tracking-wide text-blue-200 line-clamp-1">{{ featured.title }}</p>
       <h2 class="text-2xl font-bold text-white leading-tight">{{ featured.name }}</h2>
       <p class="text-sm text-blue-100 line-clamp-3">{{ featured.description }}</p>
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -85,29 +85,8 @@
                         <a href="#directory" class="bg-blue-500/30 text-white border border-white/20 hover:bg-blue-500/40 px-8 py-3 rounded-xl font-bold text-lg transition-all backdrop-blur-sm">Check the directory</a>
                     </div>
                 </div>
-                <div class="hidden lg:block animate-slide-in">
-                    <div class="bg-white/10 backdrop-blur-md border border-white/20 rounded-2xl p-8 shadow-2xl relative overflow-hidden">
-                        <div class="relative z-10">
-                            <div class="flex items-center mb-6">
-                                <img src="{{ site.baseurl }}assets/images/logos/BetterGov_Icon-White.svg" alt="BetterGov Emblem" class="h-10 w-10 mr-3">
-                                <h2 class="text-2xl font-bold">LGU Transparency</h2>
-                            </div>
-                            <div class="space-y-4">
-                                <div class="bg-white/20 p-4 rounded-xl flex items-center gap-4">
-                                    <div class="w-2 h-2 bg-green-400 rounded-full animate-pulse"></div>
-                                    <span class="font-medium">Active Maintenance</span>
-                                </div>
-                                <div class="bg-white/20 p-4 rounded-xl flex items-center gap-4 opacity-80">
-                                    <div class="w-2 h-2 bg-blue-400 rounded-full"></div>
-                                    <span class="font-medium">Open Source Templates</span>
-                                </div>
-                                <div class="bg-white/20 p-4 rounded-xl flex items-center gap-4 opacity-60">
-                                    <div class="w-2 h-2 bg-orange-400 rounded-full"></div>
-                                    <span class="font-medium">Citizen-led Initiative</span>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
+                <div class="animate-slide-in">
+                    {%- include featured-portal.html -%}
                 </div>
             </div>
         </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -274,6 +274,53 @@ main tr:last-child td {
   transform: scale(1.1);
 }
 
+/* Featured Portal card (#132) — a themed, blue-on-glass variant of the
+   generic `.lgu-tag` pill above, plus the parts of the stretched-link
+   pattern Tailwind's utilities can't express on their own: the inverted
+   badge, keyboard focus for the whole-card link, and styling the <a> tags
+   kramdown emits from `lgu.maintainer`'s raw markdown (there is no class
+   hook available on those — see _includes/featured-portal.html). */
+.featured-portal-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.25rem 0.75rem;
+  border-radius: 9999px;
+  background-color: #fff;
+  color: var(--color-primary-700);
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+}
+
+.featured-portal-card__link:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
+
+.featured-portal-card__inline-link,
+.featured-portal-card__maintainer a {
+  color: #fff;
+  font-weight: 600;
+  font-size: 0.875rem;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  text-decoration-color: rgba(255, 255, 255, 0.5);
+  transition: text-decoration-color 0.2s;
+}
+
+.featured-portal-card__inline-link:hover,
+.featured-portal-card__maintainer a:hover {
+  text-decoration-color: #fff;
+}
+
+.featured-portal-card__socials .social-icon-link {
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.featured-portal-card__socials .social-icon-link:hover {
+  color: #fff;
+}
+
 @media (max-width: 768px) {
   .prose h1 { font-size: 1.875rem; }
   .prose h2 { font-size: 1.5rem; }


### PR DESCRIPTION
## Summary

Part 2 of 2 for #132 (Implement Featured Portal). Companion to jmacj/better-lgu-directory#134 (the `main`-side crawl + scheduled rebuild) — this PR covers the `main-pages`-only site rendering (index.md's layout, CSS; this repo splits site changes into `main-pages` PRs and data/workflow changes into `main` PRs, matching #67/#68 and #106's precedent).

Replaces the hero's decorative "LGU Transparency" glass panel (`_layouts/default.html`) with a Featured Portal card, per the locked spec in #126/#129/#131/#133.

- New `_includes/featured-portal.html`: pure build-time Liquid, no JavaScript. Pool = `site.data.lgu-meta` (from #134, not yet present until that PR merges and a crawl runs — this include degrades to rendering nothing until then, which is the correct "empty pool" behaviour, not a bug) sorted by `order_key`; index = Unix day number modulo pool size, exactly as locked in #131's resolution comment. Guards the empty-pool case (no divide-by-zero, no card).
- Card fields: `⭐ Featured` badge (solid white-on-blue pill), eyebrow (portal's own meta title), heading (LGU name), description, domain, and optional maintainer/socials rows — each omitted entirely when the underlying data is absent (Cainta, Rizal has neither today, per #122).
- Stretched-link click pattern implemented via `pointer-events`, not per-element z-index: the whole card is `pointer-events-none` except the background link and the specific inline links (domain / maintainer / socials), which opt back in with `pointer-events-auto`. Domain and maintainer links stay independently clickable to their own destinations.
- Image cell uses `aspect-[1200/630]` + `object-cover`, so card height never depends on text length. `alt=""` (decorative, #133) — the eyebrow and heading already carry the same information as real text.
- Dropped `hidden lg:block` — the card now shows on every viewport; the hero's existing `grid-cols-1 lg:grid-cols-2` already stacks it below the headline/CTAs on narrow screens, so no new responsive CSS was needed.
- `assets/css/style.css`: added the `.featured-portal-*` rules for what Tailwind's utilities can't express on their own — the inverted badge pill, keyboard focus on the whole-card link, and styling the `<a>` tags `markdownify` emits from `lgu.maintainer`'s raw README markdown (no class hook is available on those).

## Acceptance criteria (this PR's share)

- [x] The Featured card renders in the hero's existing panel slot, replacing its current decorative content, glass styling matched
- [x] The card shows: eyebrow (portal meta title) → LGU name heading → description → domain → maintainer/s (omitted if empty) → socials (omitted if empty)
- [x] Clicking anywhere on the card except an inline link navigates to the featured portal; each inline link navigates to its own real destination
- [x] The card is visible on mobile viewports and stacks below the hero's headline/CTA buttons
- [x] No JavaScript ships as part of the card or its data
- [x] If `_data/lgu-meta.yml` has zero eligible rows (including "doesn't exist yet"), the Featured section does not render
- [x] Image `alt=""` (decorative) per #133
- [ ] Crawl / scheduled-rebuild AC items — covered by the companion `main` PR, not this one

## Notes for reviewer

- **Could not run a live `bundle exec jekyll build`** in this environment (no `ruby`/`bundler` installed) — the Liquid was written and hand-traced against #131's locked resolution comment (which itself flagged the exact filter chain as "not executed against a live Jekyll build" during planning) rather than compiled and visually verified. This is the biggest gap in this PR: please build it locally or check the deployed preview after merge, particularly the `date: '%s' | times: 1 | divided_by: 86400` coercion chain and the `sort: "order_key"` behaviour on an array of hashes.
- **No `_data/lgu-meta.yml` exists on `main-pages` yet** — it's generated, so I didn't hand-author one (same "never hand-edited" convention as `_data/lgus.yml`). Until #134 merges and a crawl runs (recommend a manual `workflow_dispatch` of `sync-to-pages.yml` right after), this section renders nothing, which is correct behaviour for an empty/missing pool, not a placeholder bug.
- **Join key**: the card looks up `maintainer`/`socials` via `site.data.lgus | where: "name", featured.name | first`. `_data/lgu-meta.yml` carries a `name` field for exactly this (see #134's notes) — README domain cells are markdown links (`[label](url)`), so joining on `domain` directly would never match between the two generated files.
- **Empty-pool grid cell**: per the literal AC, an empty pool renders nothing inside the `<div class="animate-slide-in">` wrapper — on `lg:` viewports that leaves an empty (but harmless) second grid column rather than collapsing to one column. Pool is 6+ today so this is a cold-start/degenerate case only; flagging rather than adding conditional grid-column CSS for a state that's expected to be rare-to-never in practice.
- **`markdownify | remove: "<p>" | remove: "</p>"`** is a standard Jekyll idiom for inline-only markdown conversion (used for the maintainer field's `[@name](url)` links) — no plugin needed, but worth a second look since it's easy to get wrong.

Closes part of #132 (see jmacj/better-lgu-directory#134 for the rest).