### PR TITLE
fix(site): overlay the Featured badge on the image per #126 locked spec

### DIFF
--- a/_includes/featured-portal.html
+++ b/_includes/featured-portal.html
@@ -51,11 +51,10 @@ emits from `lgu.maintainer`'s raw markdown).
       {%- comment -%} Decorative — the eyebrow and heading below already carry the same information as real text (#133). {%- endcomment -%}
       {%- comment -%} No loading="lazy": this card sits above the fold (#126/#129 — the hero image is the likely LCP element, and lazy-loading it above the fold would delay first paint). {%- endcomment -%}
       <img src="{{ featured.image }}" alt="" class="w-full h-full object-cover">
+      <span class="featured-portal-badge">⭐ Featured</span>
     </div>
 
     <div class="relative z-10 p-6 md:p-8 space-y-3">
-      <span class="featured-portal-badge">⭐ Featured</span>
-
       <p class="text-xs font-semibold uppercase tracking-wide text-blue-200 line-clamp-1">{{ featured.title }}</p>
       <h2 class="text-2xl font-bold text-white leading-tight">{{ featured.name }}</h2>
       <p class="text-sm text-blue-100 line-clamp-3">{{ featured.description }}</p>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -281,15 +281,27 @@ main tr:last-child td {
    kramdown emits from `lgu.maintainer`'s raw markdown (there is no class
    hook available on those — see _includes/featured-portal.html). */
 .featured-portal-badge {
+  /* Overlay pill on the image's top-left corner per #126's locked spec
+     (D/heropanel variant) — not an inline pill in the text body. #1d4ed8
+     is the spec's fixed value for this variant, not var(--color-primary-700)
+     (#003d8d), which is a different blue used elsewhere on the card. */
+  position: absolute;
+  top: 0.65rem;
+  left: 0.65rem;
+  z-index: 2;
   display: inline-flex;
   align-items: center;
   padding: 0.25rem 0.75rem;
-  border-radius: 9999px;
+  border-radius: 999px;
   background-color: #fff;
-  color: var(--color-primary-700);
-  font-size: 0.75rem;
+  color: #1d4ed8;
+  font-size: 0.6875rem;
   font-weight: 700;
-  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  letter-spacing: 0.09em;
+  box-shadow:
+    0 4px 14px rgba(0, 0, 0, 0.35),
+    0 0 0 3px rgba(255, 255, 255, 0.5);
 }
 
 .featured-portal-card__link:focus-visible {


### PR DESCRIPTION
Closes #136

## What

The `⭐ Featured` badge on the Featured Portal card shipped as a plain `inline-flex` span sitting in the card's text body — above the eyebrow/heading, in normal document flow. That's not what #126 locked: the reference prototype specs an absolutely-positioned overlay pill glued to the **image's** top-left corner, with a distinct visual treatment (uppercase, letter-spaced, glowing).

## Changes

- `_includes/featured-portal.html`: moved the `.featured-portal-badge` span out of the text-body div (`relative z-10 p-6 md:p-8 space-y-3`) and into the image cell (`relative z-0 aspect-[1200/630] ... overflow-hidden`), as a sibling of the `<img>`. The image cell already has `position: relative` via its `relative` class, so no markup change was needed there.
- `assets/css/style.css` (`.featured-portal-badge`): added `position: absolute; top: .65rem; left: .65rem; z-index: 2`; switched `border-radius` to `999px`; added `text-transform: uppercase` and widened `letter-spacing` to `.09em`; shrank font-size to `.6875rem` (~11px); added the spec's box-shadow glow (`0 4px 14px rgba(0,0,0,.35), 0 0 0 3px rgba(255,255,255,.5)`); and switched the text color from `var(--color-primary-700)` (`#003d8d`, a different blue used elsewhere on the card) to the spec's fixed `#1d4ed8` for this D/heropanel variant.

## Why this positioning is safe

The card's stretched-link pattern relies on `pointer-events: none` on the card root, with `pointer-events-auto` opted back in only on the two `<a>` tags. Neither the image cell nor the badge span sets its own `pointer-events`, so both inherit `none` from the card root — the badge doesn't intercept clicks and the full-card stretched link keeps working exactly as before. No pointer-events changes were needed.

## Verification

No Jekyll/Ruby available in this environment to render it live (same gap noted in the original #132 PRs). Verified by a careful manual diff of the computed styles against #126's resolution comment and reference prototype CSS (`.fcard-badge` / `.fcard--heropanel .fcard-badge`) — position, z-index, shape, typography, and glow all match; only the class name differs (kept the existing `.featured-portal-badge` name, per the issue's own note that names don't need to match).

## References

- #126 — locked spec (badge overlay positioning/styling)
- #132 — parent Featured Portal implementation issue
- #135 — where this defect shipped
- #136 — this fix's tracking issue