### PR TITLE
fix(featured-portal): land badge color/inset/spacing fixes missed by PR137's merge timing

### DIFF
--- a/_includes/featured-portal.html
+++ b/_includes/featured-portal.html
@@ -54,12 +54,18 @@ emits from `lgu.maintainer`'s raw markdown).
       <span class="featured-portal-badge">⭐ Featured</span>
     </div>
 
-    <div class="relative z-10 p-6 md:p-8 space-y-3">
+    <div class="relative z-10 p-6 md:p-8">
+      {%- comment -%}
+      Explicit per-gap margins instead of a flat `space-y-3`: #126 calls for
+      a distinctly tighter eyebrow-to-heading gap (0.35–0.45rem, "reads as a
+      label above the heading, not a floating fragment") while the other
+      gaps keep the card's usual ~0.75rem rhythm.
+      {%- endcomment -%}
       <p class="text-xs font-semibold uppercase tracking-wide text-blue-200 line-clamp-1">{{ featured.title }}</p>
-      <h2 class="text-2xl font-bold text-white leading-tight">{{ featured.name }}</h2>
-      <p class="text-sm text-blue-100 line-clamp-3">{{ featured.description }}</p>
+      <h2 class="mt-[0.4rem] text-2xl font-bold text-white leading-tight">{{ featured.name }}</h2>
+      <p class="mt-3 text-sm text-blue-100 line-clamp-3">{{ featured.description }}</p>
 
-      <div class="flex flex-wrap items-center gap-x-4 gap-y-2 pt-1">
+      <div class="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 pt-1">
         <a
           href="https://{{ featured.domain }}"
           class="featured-portal-card__inline-link pointer-events-auto"

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -285,10 +285,13 @@ main tr:last-child td {
      (D/heropanel variant) — not an inline pill in the text body. #2563eb
      is #126's fixed value for this badge (the D variant just inverts fill
      and text vs. the other variants), not var(--color-primary-700)
-     (#003d8d), which is a different blue used elsewhere on the card. */
+     (#003d8d), which is a different blue used elsewhere on the card.
+     Inset bumped to 1rem (from the prototype's literal .65rem) — matches
+     the card's own `rounded-2xl` (1rem) radius, so the pill clears the
+     curve of the corner instead of crowding it (Jan, live visual check). */
   position: absolute;
-  top: 0.65rem;
-  left: 0.65rem;
+  top: 1rem;
+  left: 1rem;
   z-index: 2;
   display: inline-flex;
   align-items: center;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -282,8 +282,9 @@ main tr:last-child td {
    hook available on those — see _includes/featured-portal.html). */
 .featured-portal-badge {
   /* Overlay pill on the image's top-left corner per #126's locked spec
-     (D/heropanel variant) — not an inline pill in the text body. #1d4ed8
-     is the spec's fixed value for this variant, not var(--color-primary-700)
+     (D/heropanel variant) — not an inline pill in the text body. #2563eb
+     is #126's fixed value for this badge (the D variant just inverts fill
+     and text vs. the other variants), not var(--color-primary-700)
      (#003d8d), which is a different blue used elsewhere on the card. */
   position: absolute;
   top: 0.65rem;
@@ -294,7 +295,7 @@ main tr:last-child td {
   padding: 0.25rem 0.75rem;
   border-radius: 999px;
   background-color: #fff;
-  color: #1d4ed8;
+  color: #2563eb;
   font-size: 0.6875rem;
   font-weight: 700;
   text-transform: uppercase;


### PR DESCRIPTION
## What happened

PR #137 (Closes #136 — Featured badge overlay fix) merged at 15:04:25Z. Two follow-up commits — a badge color correction and Jan's live-review inset/spacing tweaks — were pushed to the same branch (`fix/136-featured-badge-overlay`) but landed *after* that merge, so they never made it into `main-pages`. Since `main-pages` deploys continuously, the live site currently ships the wrong badge color and the old cramped inset/uniform spacing.

This PR is **not new work** — it's landing the two commits that PR #137's merge timing missed. Full context: #136, #137.

## Changes (2 commits, diff against `main-pages` is clean — only these two show up)

1. **Badge color correction** — Reviewer2 caught that `#1d4ed8` didn't match #126's actual locked spec. #126's resolution comment specifies `#2563eb` as the badge blue (D/heropanel variant inverts fill/text but keeps the same blue). `#1d4ed8` doesn't appear anywhere in #126, #132, or the repo's palette. Fixed `.featured-portal-badge`'s `color` and corrected the misleading code comment above it.

2. **Badge inset + text-body spacing** (Jan's live-review feedback on the deployed fix):
   - Badge inset bumped from the prototype's literal `.65rem` to `1rem`, matching the card's own `rounded-2xl` (1rem) radius so the pill clears the rounded corner instead of crowding it.
   - Text body spacing was a flat Tailwind `space-y-3` (uniform 0.75rem between every child). Per #126's locked spec, the eyebrow-to-heading gap should be distinctly tighter (0.35–0.45rem — "reads as a label above the heading, not a floating fragment"). Replaced `space-y-3` with explicit per-element margins: `0.4rem` eyebrow→heading, unchanged `~0.75rem` rhythm for heading→description and description→meta-row.

## Verification

No Jekyll/Ruby available in this environment to render live (same gap as the original PRs). Confirmed via `git diff origin/main-pages origin/fix/136-featured-badge-overlay` that only these two commits' changes show up — nothing from the already-merged PR #137 content re-appears in the diff.

## References

- #136 — badge overlay defect issue
- #137 — original overlay fix (merged, but missed these two follow-up commits)
- #126 — locked spec (color, spacing)