### PR TITLE
fix(featured-portal): flip rotation index at Manila midnight (#142)

### DIFF
--- a/_includes/featured-portal.html
+++ b/_includes/featured-portal.html
@@ -10,10 +10,14 @@ alphabetical (#131).
 Index: the Unix day number modulo the pool size — a pure function of the
 build's own clock, re-evaluated once a day by the scheduled rebuild in
 `.github/workflows/rebuild-featured.yml`. `date: '%s'` returns a string, so it
-is coerced with `times: 1` before the integer division — see
-scripts/test-rotation-index.js for the arithmetic proof (#131 flagged this
-chain as unverified against a live Jekyll build; verify it here on first
-deploy).
+is coerced with `times: 1` before the integer division. #132's cadence is
+meant to flip at 00:00 Asia/Manila (UTC+8), not 00:00 UTC — the scheduled
+rebuild fires at 16:00 UTC for exactly that reason — so the epoch seconds are
+shifted by `plus: 28800` (Manila's +8h offset, in seconds) before the
+divide-by-86400, moving the day-floor boundary from UTC midnight to Manila
+midnight (#142). See scripts/test-rotation-index.js for the arithmetic proof
+(#131 flagged this chain as unverified against a live Jekyll build; verify it
+here on first deploy).
 
 If the pool is empty, this include renders nothing — no divide-by-zero, no
 placeholder card (#125's no-fallback rule extends to the degenerate case).
@@ -26,7 +30,7 @@ emits from `lgu.maintainer`'s raw markdown).
 {%- endcomment -%}
 {%- assign pool = site.data.lgu-meta | sort: "order_key" -%}
 {%- if pool and pool.size > 0 -%}
-  {%- assign day = site.time | date: '%s' | times: 1 | divided_by: 86400 -%}
+  {%- assign day = site.time | date: '%s' | times: 1 | plus: 28800 | divided_by: 86400 -%}
   {%- assign i = day | modulo: pool.size -%}
   {%- assign featured = pool[i] -%}
   {%- assign lgu = site.data.lgus | where: "name", featured.name | first -%}


### PR DESCRIPTION
## Summary

Part 1 of 2 for #142 (rotation day-boundary fix). This PR covers the `main-pages`-side render fix — the companion `main` PR (test script) is separate, matching the #132/#134/#135 split-brain precedent for this repo (site changes on `main-pages`, data/script changes on `main`).

- `_includes/featured-portal.html`'s day computation was a pure Unix-epoch-day calc with no timezone offset, so it flipped at `00:00 UTC` (`08:00 Manila`) instead of `00:00 Asia/Manila` as #132's cadence intended — the scheduled rebuild in `.github/workflows/rebuild-featured.yml` fires at `16:00 UTC` for exactly the reason that it equals Manila midnight, but the index math itself never accounted for that offset.
- Fix: `{%- assign day = site.time | date: '%s' | times: 1 | plus: 28800 | divided_by: 86400 -%}` — shifts the epoch seconds by `+28800` (Manila's UTC+8 offset, in seconds) before the floor-division, so the day boundary lands exactly on `16:00 UTC` = `00:00 Asia/Manila` instead of `00:00 UTC`.
- Updated the include's comment block to describe the Manila-midnight rationale instead of leaving it implicitly UTC-midnight.

## Why the math is correct (walked through)

Manila is UTC+8, so Manila midnight occurs when UTC is still `16:00` the previous day. Adding `28800`s (8h) to the epoch timestamp before floor-dividing by `86400` re-bases the floor-division boundary onto that 16:00 UTC instant:

- At `15:59:59 UTC`: shifted value is `86399`s into the current day bucket → day stays `N`.
- At `16:00:00 UTC`: shifted value is exactly `86400`s → day flips to `N+1`.

So the transition happens precisely between `15:59:59 UTC` and `16:00:00 UTC` — i.e. between `23:59:59 Manila` and `00:00:00 Manila`. Confirmed concretely for `2026-08-01T16:00:00Z` (the scheduled rebuild's own fixed cron moment): old math gave day `20666` (still inside the previous day), new math gives day `20667` exactly, landing on the boundary the rebuild is designed to hit.

## Acceptance criteria (this PR's share)

- [x] `_includes/featured-portal.html`'s day computation includes the `plus: 28800` step before `divided_by: 86400`, with its comment block updated to describe the Manila-midnight boundary
- [ ] Test-script + stale-comment AC items — covered by the companion `main` PR, not this one

## Notes for reviewer

- Could not run a live `bundle exec jekyll build` in this environment (no `ruby`/`bundler`) — verified the arithmetic by hand-tracing the filter chain (see above) and will cross-check against the companion `main` PR's Node reimplementation of the same chain, which I did run.
- No other stale "flips at UTC midnight" comments found elsewhere in this branch's tree (`grep`'d for "UTC midnight"/"00:00 UTC"/"midnight UTC").
- Per this repo's own convention ("Contributors are requested to not update CHANGELOG.md in their Pull Requests"), CHANGELOG.md is intentionally left untouched, consistent with #134/#135.

Closes #142