### PR TITLE
fix(featured-portal): restore regular badge size, keep vertical alignment

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -296,7 +296,15 @@ main tr:last-child td {
   display: inline-flex;
   align-items: center;
   gap: 0.3em;
-  line-height: 1;
+  /* 1.4 (not 1) matches #126's prototype `font: 700 11px/1.4 …` reference —
+     #140's line-height:1 fixed vertical misalignment but flattened the
+     pill's line-box, making it read as compact vs. the locked spec. All
+     three rules here (parent + both inner spans) must share this value:
+     the parent's line-height no longer directly sizes anything (icon/label
+     are the flex items now), but keeping it consistent avoids a stray
+     mismatched line-box if a future edit adds text directly to the parent
+     again. */
+  line-height: 1.4;
   padding: 0.25rem 0.75rem;
   border-radius: 999px;
   background-color: #fff;
@@ -318,18 +326,31 @@ main tr:last-child td {
    the icon gets its own line-height/vertical nudge since emoji glyphs
    commonly render with extra internal leading that text characters don't
    have — 1 (inherited from the parent) still isn't enough to visually
-   center the glyph against the label's cap-height/x-height. */
+   center the glyph against the label's cap-height/x-height.
+
+   line-height bumped from 1 to 1.4 (regression fix, follow-up to #141 —
+   flat line-height:1 was making the whole pill read as compact vs. #126's
+   locked spec). The 0.05em translateY nudge is UNCHANGED and still
+   correct at 1.4: the nudge compensates for the emoji glyph's own
+   optical position inside its em-box, a font-metric bias that's
+   independent of line-height. Growing line-height only adds equal
+   half-leading above and below the existing content of BOTH spans
+   (icon and label share the same 1.4 value), so it enlarges the two
+   line-boxes symmetrically around their prior centers — it doesn't
+   reintroduce or shift the relative offset the nudge was tuned to
+   correct. Re-verify visually if the font-size or nudge value ever
+   changes together. */
 .featured-portal-badge__icon {
   display: inline-flex;
   align-items: center;
-  line-height: 1;
+  line-height: 1.4;
   transform: translateY(0.05em);
 }
 
 .featured-portal-badge__label {
   display: inline-flex;
   align-items: center;
-  line-height: 1;
+  line-height: 1.4;
 }
 
 .featured-portal-card__link:focus-visible {


### PR DESCRIPTION
## Summary

- #140/PR #141 fixed the Featured Portal badge's icon/label vertical misalignment, but set `line-height: 1` on the parent `.featured-portal-badge` and both new `__icon`/`__label` spans. That flattened the pill's line-box height — padding and font-size were untouched — and Jan reported the badge now looks "compact, not regular size" vs. before.
- Restores `line-height: 1.4` on all three rules, matching #126's original locked-spec prototype (`font: 700 11px/1.4 ui-sans-serif,system-ui,sans-serif`), so the pill reads as regular size again.
- Leaves the icon's `transform: translateY(0.05em)` nudge unchanged. Reasoning: the nudge corrects for the emoji glyph's own optical bias within its em-box — a font-metric offset in `em` units tied to font-size, not line-height. Bumping line-height to 1.4 adds equal half-leading above and below the content of *both* spans (icon and label share the same value), enlarging their line-boxes symmetrically around their prior centers. It doesn't shift the relative vertical offset the nudge was tuned to correct, so #140's centering fix should still hold.

Closes #144

## Notes for reviewer

- No Jekyll/Ruby available in this environment to render the site live — same limitation noted in the prior #140/#141 rounds. Verification here is careful manual CSS/box-model reasoning (line-box height math, flex `align-items: center` behavior for inline-flex spans), not a rendered screenshot. Worth a real visual check when this lands.
- Did not touch `CHANGELOG.md` — this repo's changelog explicitly asks contributors not to edit it ("This file is updated by the repository maintainers").
- Dedupe-checked before filing: `gh issue list --search "badge compact"` / `--search "badge size"` — no prior issue covered this size regression.