### PR TITLE
feat(site): render repository activity in the directory row (#162)

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -249,6 +249,47 @@ main tr:last-child td {
 .animate-fade-in { animation: fadeIn 0.5s ease-in-out forwards; }
 .animate-slide-in { animation: slideIn 0.5s ease-out forwards; }
 
+/* Repository activity (#162) — second line inside the Repository cell,
+   after a <br> (same pattern as .lgu-tag below — a sibling element, not a
+   wrapper around the primary markdown-rendered link, so kramdown's normal
+   span-level parsing of {{ lgu.repo }} is untouched).
+   `.repo-activity` reserves its final height from the start via min-height
+   on an inline-block, so injecting the loading skeleton, then the real
+   value, never reflows the table — see DESIGN.md on
+   prototype/repo-activity-ui. */
+.repo-activity {
+  display: inline-block;
+  min-height: 1.1rem;
+  font-size: 0.75rem;
+  line-height: 1.1rem;
+  color: var(--color-gray-600);
+}
+
+.repo-activity time {
+  border-bottom: 1px dotted var(--color-gray-400);
+  cursor: help;
+}
+
+.repo-activity-none {
+  color: var(--color-gray-500);
+}
+
+.repo-activity-skeleton {
+  display: inline-block;
+  width: 7rem;
+  height: 0.65rem;
+  border-radius: 0.25rem;
+  background: linear-gradient(90deg, var(--color-gray-200) 25%, var(--color-gray-100) 37%, var(--color-gray-200) 63%);
+  background-size: 400% 100%;
+  animation: repoActivityShimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes repoActivityShimmer { 0% { background-position: 100% 0; } 100% { background-position: 0 0; } }
+
+@media (prefers-reduced-motion: reduce) {
+  .repo-activity-skeleton { animation: none; }
+}
+
 .sr-only {
   position: absolute;
   width: 1px;

--- a/assets/js/repo-activity.js
+++ b/assets/js/repo-activity.js
@@ -1,0 +1,286 @@
+// Repository activity (#162): the "Updated N days ago" second line inside
+// each directory row's Repository cell. Client-side, unauthenticated GitHub
+// API, never stored in this repository — see DESIGN.md on
+// prototype/repo-activity-ui for the full design record and reasoning.
+//
+// This is a plain script (no bundler/build step on this branch), so it's
+// wrapped in an IIFE and attaches nothing to `window` except through the
+// DOM it renders into. The handful of pure functions (bucket/exactDate/
+// ttlMs/isFresh) are exported via `module.exports` when running under
+// Node, purely so scripts/test-repo-activity.js can exercise them with
+// zero dependencies — that branch of the export never runs in the browser.
+(function () {
+    'use strict';
+
+    var CACHE_PREFIX = 'ghcache:';
+    var CONCURRENCY = 3;
+    var ROOT_MARGIN = '200px';
+    var HOUR_MS = 3600000;
+    var DAY_MS = 24 * HOUR_MS;
+
+    // -------------------------------------------------------------------
+    // Pure helpers — no DOM, no network, no storage. Kept side-effect free
+    // so they can be unit tested directly.
+    // -------------------------------------------------------------------
+
+    // Display bucketing. Day granularity is deliberate: TTL is measured in
+    // hours, so hour-level precision would be precision the cache can't
+    // back — never show it.
+    function bucket(iso, now) {
+        var then = new Date(iso).getTime();
+        var days = Math.floor(((now == null ? Date.now() : now) - then) / DAY_MS);
+        if (days <= 0) return 'today';
+        if (days === 1) return 'yesterday';
+        if (days < 7) return days + ' days ago';
+        if (days < 30) {
+            var w = Math.floor(days / 7);
+            return w + (w === 1 ? ' week ago' : ' weeks ago');
+        }
+        if (days < 365) {
+            var m = Math.floor(days / 30);
+            return m + (m === 1 ? ' month ago' : ' months ago');
+        }
+        var y = Math.floor(days / 365);
+        return y + (y === 1 ? ' year ago' : ' years ago');
+    }
+
+    function exactDate(iso) {
+        return new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+    }
+
+    // Cache TTL as a function of the *commit's* age, not the cache entry's
+    // age — a repo touched 8 months ago can't change bucket within a week;
+    // one touched this morning can flip bucket by tonight. See DESIGN.md.
+    function ttlMs(pushedAtIso, now) {
+        var hrs = ((now == null ? Date.now() : now) - new Date(pushedAtIso).getTime()) / HOUR_MS;
+        if (hrs < 24) return 1 * HOUR_MS;
+        if (hrs < 24 * 7) return 6 * HOUR_MS;
+        return 7 * DAY_MS;
+    }
+
+    // Whether a cached entry is still usable without hitting the network.
+    // A "not found" (404) result is cached and treated like the oldest TTL
+    // band (7 days) — a deleted/renamed/private repo doesn't come back
+    // quickly, and re-checking it on every page view would burn quota for
+    // no benefit.
+    function isFresh(entry, now) {
+        now = now == null ? Date.now() : now;
+        if (!entry || typeof entry.fetchedAt !== 'number') return false;
+        if (entry.notFound) return (now - entry.fetchedAt) < (7 * DAY_MS);
+        if (!entry.pushedAt) return false;
+        return (now - entry.fetchedAt) < ttlMs(entry.pushedAt, entry.fetchedAt);
+    }
+
+    // -------------------------------------------------------------------
+    // Everything below touches the DOM, localStorage, or the network —
+    // none of it runs (or is reachable) under the Node test.
+    // -------------------------------------------------------------------
+
+    var hasDom = typeof document !== 'undefined' && typeof window !== 'undefined';
+
+    if (hasDom) {
+        (function runInBrowser() {
+            // ---- localStorage cache, degrading silently if unavailable
+            // (quota exceeded, private browsing, disabled). ----
+
+            function readCache(key) {
+                try {
+                    var raw = window.localStorage.getItem(key);
+                    if (!raw) return null;
+                    var parsed = JSON.parse(raw);
+                    return parsed && typeof parsed === 'object' ? parsed : null;
+                } catch (e) {
+                    return null;
+                }
+            }
+
+            function writeCache(key, entry) {
+                try {
+                    window.localStorage.setItem(key, JSON.stringify(entry));
+                } catch (e) {
+                    // Full, disabled, or private mode — proceed without a cache.
+                }
+            }
+
+            // ---- concurrency queue: 2-3 in flight, so a fast scroll to the
+            // bottom of a 100-per-page listing doesn't burst every visible
+            // row's request at once. ----
+
+            function createQueue(limit) {
+                var active = 0;
+                var pending = [];
+
+                function runNext() {
+                    if (active >= limit || pending.length === 0) return;
+                    active++;
+                    var job = pending.shift();
+                    job.task().then(job.resolve, job.reject).then(function () {
+                        active--;
+                        runNext();
+                    });
+                }
+
+                return function enqueue(task) {
+                    return new Promise(function (resolve, reject) {
+                        pending.push({ task: task, resolve: resolve, reject: reject });
+                        runNext();
+                    });
+                };
+            }
+
+            var enqueue = createQueue(CONCURRENCY);
+
+            // ---- in-flight promise dedupe: two cells never fetch the same
+            // repo twice concurrently. ----
+
+            var inFlight = {};
+
+            function fetchActivity(owner, repo) {
+                var slug = owner + '/' + repo;
+                if (inFlight[slug]) return inFlight[slug];
+                var promise = enqueue(function () { return doFetch(slug); }).then(
+                    function (result) { delete inFlight[slug]; return result; },
+                    function (err) { delete inFlight[slug]; throw err; },
+                );
+                inFlight[slug] = promise;
+                return promise;
+            }
+
+            // ETag revalidation saves bandwidth only — a 304 still
+            // decrements the rate limit (measured against the live API,
+            // see DESIGN.md), so it is not a substitute for the TTL, which
+            // is the real quota control here.
+            function doFetch(slug) {
+                var cacheKey = CACHE_PREFIX + slug;
+                var cached = readCache(cacheKey);
+                var headers = {};
+                if (cached && cached.etag) headers['If-None-Match'] = cached.etag;
+
+                return fetch('https://api.github.com/repos/' + slug, { headers: headers })
+                    .then(function (res) {
+                        if (res.status === 304 && cached) {
+                            var revalidated = {
+                                pushedAt: cached.pushedAt,
+                                etag: cached.etag,
+                                fetchedAt: Date.now(),
+                            };
+                            writeCache(cacheKey, revalidated);
+                            return revalidated;
+                        }
+                        if (res.status === 404) {
+                            var notFound = { notFound: true, fetchedAt: Date.now() };
+                            writeCache(cacheKey, notFound);
+                            return notFound;
+                        }
+                        if (!res.ok) {
+                            // Rate-limited (403/429) or any other non-ok
+                            // status: fall back to stale cache if we have
+                            // one, else render neutral — never surface the
+                            // status code.
+                            return cached;
+                        }
+                        return res.json().then(function (data) {
+                            var entry = {
+                                pushedAt: data.pushed_at,
+                                etag: res.headers.get('ETag') || undefined,
+                                fetchedAt: Date.now(),
+                            };
+                            writeCache(cacheKey, entry);
+                            return entry;
+                        });
+                    })
+                    .catch(function () {
+                        // Network error: same neutral fallback as rate-limited.
+                        return cached;
+                    });
+            }
+
+            // ---- rendering: three states, matching prototype.html. The
+            // observed/handled element (`.repo-activity[data-repo]`) IS the
+            // line to fill — a sibling of the repo link after a <br>, not a
+            // wrapper around it, so kramdown's markdown parsing of
+            // {{ lgu.repo }} is never touched by this script. ----
+
+            function renderLoading(el) {
+                el.innerHTML = '<span class="repo-activity-skeleton" aria-hidden="true"></span>';
+            }
+
+            function renderNone(el) {
+                el.innerHTML = '<span class="repo-activity-none">—</span>';
+            }
+
+            function renderValue(el, iso) {
+                el.textContent = 'Updated ';
+                var time = document.createElement('time');
+                time.setAttribute('datetime', iso);
+                time.setAttribute('title', exactDate(iso));
+                time.textContent = bucket(iso);
+                el.appendChild(time);
+            }
+
+            function handleCell(el) {
+                var slug = el.getAttribute('data-repo');
+                if (!slug || slug.indexOf('/') === -1) return;
+                var cacheKey = CACHE_PREFIX + slug;
+                var cached = readCache(cacheKey);
+
+                // Fast path: a fresh cache entry needs no network at all —
+                // satisfies "repeat visits within the TTL make no request."
+                if (cached && isFresh(cached)) {
+                    if (cached.notFound) renderNone(el); else renderValue(el, cached.pushedAt);
+                    return;
+                }
+
+                renderLoading(el);
+                var slashIndex = slug.indexOf('/');
+                var owner = slug.slice(0, slashIndex);
+                var repo = slug.slice(slashIndex + 1);
+                fetchActivity(owner, repo).then(function (entry) {
+                    if (!entry || entry.notFound || !entry.pushedAt) {
+                        renderNone(el);
+                        return;
+                    }
+                    renderValue(el, entry.pushedAt);
+                });
+            }
+
+            // ---- fetch gating: pagination (existing show/hide) decides the
+            // candidate set — a hidden (display:none) row cannot intersect,
+            // so it never triggers a fetch until paged into view;
+            // IntersectionObserver decides exactly when a visible row
+            // fires. Complementary, not alternatives — see DESIGN.md. ----
+
+            function init() {
+                var cells = document.querySelectorAll('.repo-activity[data-repo]');
+                if (!cells.length) return;
+
+                if (!('IntersectionObserver' in window)) {
+                    // No IO support: still gated by the concurrency queue,
+                    // so this degrades to "slower," not "bursts every row."
+                    cells.forEach(handleCell);
+                    return;
+                }
+
+                var observer = new IntersectionObserver(function (entries) {
+                    entries.forEach(function (entry) {
+                        if (!entry.isIntersecting) return;
+                        observer.unobserve(entry.target);
+                        handleCell(entry.target);
+                    });
+                }, { rootMargin: ROOT_MARGIN });
+
+                cells.forEach(function (cell) { observer.observe(cell); });
+            }
+
+            if (document.readyState === 'loading') {
+                document.addEventListener('DOMContentLoaded', init);
+            } else {
+                init();
+            }
+        })();
+    }
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = { bucket: bucket, exactDate: exactDate, ttlMs: ttlMs, isFresh: isFresh };
+    }
+})();

--- a/index.md
+++ b/index.md
@@ -39,7 +39,7 @@ A community-maintained directory of **Better LGU** digital transparency portals 
 
 | LGU                             | Domain                                                | Repository                                                                     | Socials                                                            | Status    | Maintainer/s                                                                           |
 |---------------------------------|-------------------------------------------------------|--------------------------------------------------------------------------------|--------------------------------------------------------------------|-----------|----------------------------------------------------------------------------------------|
-{% for lgu in site.data.lgus %}| {{ lgu.name }} | {{ lgu.domain }} | {{ lgu.repo }} | {% if lgu.socials and lgu.socials.size > 0 %}<span class="inline-flex items-center gap-3 flex-wrap">{% for s in lgu.socials %}{% include social-icon.html label=s.label url=s.url %}{% endfor %}</span>{% else %}-{% endif %} | {{ lgu.status }}{% if lgu.stale %}<br><span class="lgu-tag lgu-tag-stale">⚠️ Stale</span>{% endif %} | {{ lgu.maintainer }}{% if lgu.open_for_adoption %}<br><span class="lgu-tag lgu-tag-adoption">🤝 Open for Adoption</span>{% endif %} |
+{% for lgu in site.data.lgus %}| {{ lgu.name }} | {{ lgu.domain }} | {{ lgu.repo }}{% if lgu.repo_owner %}<br><span class="repo-activity" data-repo="{{ lgu.repo_owner }}/{{ lgu.repo_name }}"></span>{% endif %} | {% if lgu.socials and lgu.socials.size > 0 %}<span class="inline-flex items-center gap-3 flex-wrap">{% for s in lgu.socials %}{% include social-icon.html label=s.label url=s.url %}{% endfor %}</span>{% else %}-{% endif %} | {{ lgu.status }}{% if lgu.stale %}<br><span class="lgu-tag lgu-tag-stale">⚠️ Stale</span>{% endif %} | {{ lgu.maintainer }}{% if lgu.open_for_adoption %}<br><span class="lgu-tag lgu-tag-adoption">🤝 Open for Adoption</span>{% endif %} |
 {% endfor %}
 
 </div>
@@ -144,6 +144,10 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for how to add or update an LGU entry, co
 ## 📄 License
 
 Content in this repository is licensed under [CC BY 4.0](LICENSE). Templates in linked repositories carry their own licenses.
+
+<!-- Repository activity (#162) — fills in the "Updated N days ago" line under
+     each row's GitHub link. See assets/js/repo-activity.js. -->
+<script defer src="{{ site.baseurl }}assets/js/repo-activity.js"></script>
 
 <!-- Search and Pagination Script -->
 <script>

--- a/scripts/test-repo-activity-site.js
+++ b/scripts/test-repo-activity-site.js
@@ -4,7 +4,7 @@
 // this is a plain Node script using the built-in `assert` module, following
 // the scripts/test-rotation-index.js pattern. Run with:
 //
-//   node scripts/test-repo-activity.js
+//   node scripts/test-repo-activity-site.js
 //
 // It exits non-zero on any failure.
 //
@@ -14,10 +14,15 @@
 // `main-pages` side: the pure bucket/exactDate/ttlMs/isFresh functions
 // exported from assets/js/repo-activity.js. The repo-URL parsing
 // (parseRepoCell in scripts/sync-to-data.js) lives on `main` and is covered
-// by that branch's own scripts/test-repo-activity.js — it cannot be
+// by that branch's own scripts/test-repo-activity-data.js — it cannot be
 // required from here since main-pages has no sync-to-data.js parser logic
 // for it (main-pages's copy is a mirror kept in sync by the automated merge,
 // not a place new tests are added).
+//
+// Named `-site` (not the bare `test-repo-activity.js` this file and #163's
+// companion both originally used) specifically so the two don't collide
+// when sync-to-pages.yml's `git merge origin/main` runs after both land —
+// same path, unrelated content, guaranteed conflict otherwise.
 
 const assert = require('assert');
 const { bucket, exactDate, ttlMs, isFresh } = require('../assets/js/repo-activity.js');

--- a/scripts/test-repo-activity.js
+++ b/scripts/test-repo-activity.js
@@ -1,0 +1,99 @@
+// Zero-dependency regression test for the repository activity display
+// buckets and cache TTL rules (#162), the site-side (main-pages) half of the
+// feature. This repo has no package.json / test runner on either branch, so
+// this is a plain Node script using the built-in `assert` module, following
+// the scripts/test-rotation-index.js pattern. Run with:
+//
+//   node scripts/test-repo-activity.js
+//
+// It exits non-zero on any failure.
+//
+// Scope note: #162 splits across two branches (see CONTEXT.md's "Sync
+// pipeline" entry and the #132 precedent — data/workflow changes land on
+// `main`, site rendering on `main-pages`). This file covers only the
+// `main-pages` side: the pure bucket/exactDate/ttlMs/isFresh functions
+// exported from assets/js/repo-activity.js. The repo-URL parsing
+// (parseRepoCell in scripts/sync-to-data.js) lives on `main` and is covered
+// by that branch's own scripts/test-repo-activity.js — it cannot be
+// required from here since main-pages has no sync-to-data.js parser logic
+// for it (main-pages's copy is a mirror kept in sync by the automated merge,
+// not a place new tests are added).
+
+const assert = require('assert');
+const { bucket, exactDate, ttlMs, isFresh } = require('../assets/js/repo-activity.js');
+
+let assertions = 0;
+function check(condition, message) {
+    assertions++;
+    assert.ok(condition, message);
+}
+
+const DAY_MS = 86400000;
+const HOUR_MS = 3600000;
+const NOW = Date.UTC(2026, 7, 10, 12, 0, 0); // 2026-08-10T12:00:00Z, arbitrary fixed "now"
+
+function daysAgoIso(days, fromMs = NOW) {
+    return new Date(fromMs - days * DAY_MS).toISOString();
+}
+function hoursAgoIso(hours, fromMs = NOW) {
+    return new Date(fromMs - hours * HOUR_MS).toISOString();
+}
+
+// --- display buckets ---------------------------------------------------
+
+check(bucket(hoursAgoIso(0), NOW) === 'today', 'a commit from right now buckets as "today"');
+check(bucket(hoursAgoIso(23), NOW) === 'today', 'a commit 23h ago (same day) buckets as "today", never hour-level precision');
+check(bucket(daysAgoIso(1), NOW) === 'yesterday', 'a commit 1 day ago buckets as "yesterday"');
+check(bucket(daysAgoIso(2), NOW) === '2 days ago', 'a commit 2 days ago buckets as "2 days ago"');
+check(bucket(daysAgoIso(6), NOW) === '6 days ago', 'a commit 6 days ago is still expressed in days (< 7)');
+check(bucket(daysAgoIso(7), NOW) === '1 week ago', 'a commit exactly 7 days ago rolls over to "1 week ago" (singular)');
+check(bucket(daysAgoIso(13), NOW) === '1 week ago', 'a commit 13 days ago is still "1 week ago" (floor division)');
+check(bucket(daysAgoIso(14), NOW) === '2 weeks ago', 'a commit 14 days ago is "2 weeks ago" (plural)');
+check(bucket(daysAgoIso(29), NOW) === '4 weeks ago', 'a commit 29 days ago is still expressed in weeks (< 30)');
+check(bucket(daysAgoIso(30), NOW) === '1 month ago', 'a commit exactly 30 days ago rolls over to "1 month ago" (singular)');
+check(bucket(daysAgoIso(60), NOW) === '2 months ago', 'a commit 60 days ago is "2 months ago" (plural)');
+check(bucket(daysAgoIso(364), NOW) === '12 months ago', 'a commit 364 days ago is still expressed in months (< 365)');
+check(bucket(daysAgoIso(365), NOW) === '1 year ago', 'a commit exactly 365 days ago rolls over to "1 year ago" (singular)');
+check(bucket(daysAgoIso(800), NOW) === '2 years ago', 'a commit 800 days ago is "2 years ago" (plural)');
+
+check(!/\d+\s*h(ou)?r/i.test(bucket(hoursAgoIso(3), NOW)), 'never renders hour-level precision, even for a very recent commit');
+
+// --- exact date (the hover title) ---------------------------------------
+
+check(exactDate('2026-08-07T14:22:10Z') === 'August 7, 2026', 'exactDate renders a human month/day/year, matching the datetime attribute');
+
+// --- cache TTL bands, by commit age -------------------------------------
+
+check(ttlMs(hoursAgoIso(0), NOW) === HOUR_MS, 'a commit from right now gets the 1h TTL band');
+check(ttlMs(hoursAgoIso(23), NOW) === HOUR_MS, 'a commit 23h old is still in the <24h -> 1h TTL band');
+check(ttlMs(hoursAgoIso(24), NOW) === 6 * HOUR_MS, 'a commit exactly 24h old rolls into the 6h TTL band');
+check(ttlMs(daysAgoIso(6), NOW) === 6 * HOUR_MS, 'a commit 6 days old is still in the <7d -> 6h TTL band');
+check(ttlMs(daysAgoIso(7), NOW) === 7 * DAY_MS, 'a commit exactly 7 days old rolls into the 7d TTL band');
+check(ttlMs(daysAgoIso(240), NOW) === 7 * DAY_MS, 'a commit 8 months old is in the immovable 7d TTL band');
+
+// --- isFresh: whether a cached entry needs no network request -----------
+
+{
+    const entry = { pushedAt: hoursAgoIso(1, NOW), fetchedAt: NOW };
+    check(isFresh(entry, NOW) === true, 'a cache entry fetched right now is fresh at that same instant');
+    check(isFresh(entry, NOW + 30 * 60000) === true, 'a <24h-commit cache entry is still fresh 30 minutes later (within its 1h TTL)');
+    check(isFresh(entry, NOW + 2 * HOUR_MS) === false, 'a <24h-commit cache entry goes stale after its 1h TTL elapses');
+}
+{
+    // Most of the ~55 repos sit in the oldest band — worth its own case.
+    const entry = { pushedAt: daysAgoIso(240, NOW), fetchedAt: NOW };
+    check(isFresh(entry, NOW + 6 * DAY_MS) === true, 'an old-commit cache entry is still fresh 6 days later (within its 7d TTL)');
+    check(isFresh(entry, NOW + 8 * DAY_MS) === false, 'an old-commit cache entry goes stale after its 7d TTL elapses');
+}
+check(isFresh(null, NOW) === false, 'no cache entry is never fresh');
+check(isFresh({}, NOW) === false, 'a malformed cache entry (no fetchedAt) is never fresh');
+{
+    // 404 / private / deleted repos are cached too, so a repeat visit
+    // doesn't re-request a repo that's gone — same rationale as the oldest
+    // TTL band (7d): a dead link doesn't come back quickly.
+    const notFound = { notFound: true, fetchedAt: NOW };
+    check(isFresh(notFound, NOW + 6 * DAY_MS) === true, 'a cached 404 result stays fresh for up to 7 days');
+    check(isFresh(notFound, NOW + 8 * DAY_MS) === false, 'a cached 404 result goes stale after 7 days, so it gets re-checked eventually');
+}
+
+console.log(`✅ ${assertions} assertions passed.`);


### PR DESCRIPTION
## Summary

Part 2 of 2 for #162 (Show repository activity — last commit date — in each
directory row). Companion to jmacj/better-lgu-directory#163 (the `main`-side
`repo_owner`/`repo_name` enabling change) — this PR covers the `main-pages`
only site rendering, matching this repo's main vs main-pages split
(`CONTEXT.md`'s "Sync pipeline" entry, and the #132 → #134/#135 precedent).

Full design record: [`DESIGN.md`](https://github.com/jmacj/better-lgu-directory/blob/prototype/repo-activity-ui/DESIGN.md)
and [`prototype.html`](https://github.com/jmacj/better-lgu-directory/blob/prototype/repo-activity-ui/prototype.html)
on `prototype/repo-activity-ui`.

- **`index.md`**: `{{ lgu.repo }}` gains a `<br><span class="repo-activity" data-repo="owner/name">` sibling when `lgu.repo_owner` is present (from #163) — deliberately the *same shape* as the existing `⚠️ Stale`/`🤝 Open for Adoption` tags (`{{ x }}{% if %}<br><span>...</span>{% endif %}`), not a wrapper around the repo link. Entries with no repo link render nothing extra. No new column — `filterDirectory()`'s `td[4]`/`td[5]` indexes are untouched.
- **`assets/js/repo-activity.js`** (new): finds every `.repo-activity[data-repo]`, wires an `IntersectionObserver` (200px `rootMargin`) so a row only fetches once scrolled into view — complementary to the existing pagination's show/hide, which already keeps off-page rows at `display:none` and therefore non-intersecting. Gated through a 3-in-flight concurrency queue so a fast scroll to the bottom of a 100-per-page listing doesn't burst. `localStorage` cache keyed `ghcache:owner/name`, TTL by *commit* age (<24h → 1h, <7d → 6h, older → 7d — most of the ~55 repos sit in the immovable 7d band). ETag revalidation for bandwidth only — a 304 still costs a rate-limit request, so TTL is the real quota control, not the ETag. In-flight promise dedupe. Three render states: skeleton, `<time datetime title>` value, neutral `—`. Rate-limited (403/429), network error, and 404 all render the same neutral `—` — never an error string or status code. A 404 result is cached too (treated like the oldest TTL band) so a dead repo link isn't re-checked on every page view.
- **`assets/css/style.css`**: `.repo-activity` reserves its line's final height via `min-height` on an `inline-block` from the start, so skeleton → value never reflows the table.
- **`scripts/test-repo-activity-site.js`** (new, this branch's own): zero-dependency `node:assert` coverage of `bucket`/`exactDate`/`ttlMs`/`isFresh` — bucket boundaries (including singular/plural wording and the never-hour-precision rule), the three TTL bands, and `isFresh` including the cached-404 case. Follows `test-rotation-index.js`'s pattern. `node scripts/test-repo-activity-site.js` → 31/31 passing. (The repo-URL parsing half of #162's test AC lives in #163's own `scripts/test-repo-activity-data.js` on `main` — see that PR; the two can't share one file since the code under test is split across branches. Originally both branches used the bare `test-repo-activity.js` name — renamed both, see "Fixed in review" below.)

## Acceptance criteria (this PR's share)

- [x] Directory rows render `data-repo="owner/name"`; rows without a repo have no attribute
- [x] Visible rows with a repo show the last-updated line under the GitHub link
- [x] The visible string is computed at render from `<time datetime>`, bucketed to day granularity; hovering shows the exact date
- [x] A loading skeleton occupies the line's final height, so filling it in causes no reflow
- [x] Rate-limited, network error, and 404 all render a neutral `—` — never an error message, never a status code
- [x] Rows with no repo link render nothing extra
- [x] Repeat visits within the TTL make no network request
- [x] Selecting 100 per page does not fire ~55 requests at once; rows fetch as they scroll into view
- [x] A zero-dependency Node `assert` test covers the bucket/TTL rules
- [x] `_data/lgus.yml` carries structured `owner`/`repo`, `check-stale.js`/`triage-pr.js` still work, `CONTEXT.md`'s glossary entry, `CHANGELOG.md` — all in #163, not this PR

Closes #162 (together with #163 — see that PR for its share of the AC).

## Notes for reviewer

- **Judgment call — DOM shape deviates from `prototype.html` and `DESIGN.md`'s literal wording.** Both describe `data-repo` as stamped "on the row" / "onto each row," and the prototype puts it on `<tr>`. I put it on the `.repo-activity` span inside the Repository `<td>` instead. Reason: `index.md`'s directory table is written in kramdown pipe-table syntax (`| {{ lgu.name }} | ... |`), which has no mechanism to attach a raw HTML attribute to the generated `<tr>` without restructuring the entire table to raw HTML — a materially riskier change to a production Jekyll template (and to `filterDirectory()`'s row-scanning) than this feature calls for. Placing `data-repo` on `.repo-activity` (a) is exactly the element the script needs to find and fill anyway, no traversal required, (b) reuses the *proven* `{% if %}<br><span>...</span>{% endif %}` pattern already used for the Stale/Adoption tags, instead of introducing an unproven wrapper-span-around-a-markdown-link shape (I tried that first — a `<span class="repo-cell">{{ lgu.repo }}<span>...</span></span>` wrapper — and backed it out specifically because it's untested territory for how kramdown parses a markdown link nested inside another inline HTML element on this branch, and I have no Jekyll runtime available in this environment to verify it either way). Functionally equivalent for every AC item; flagging since it's a literal-text deviation from the design doc.
- **Could not run a real `bundle exec jekyll build`** — no `ruby`/`bundler` in this environment (same gap #134 hit). Verified instead via: `node --check` on the new JS, the full `test-repo-activity-site.js` suite, and manually regenerating a real `_data/lgus.yml` locally (using #163's updated `sync-to-data.js` from its branch, then reverting that copy — it doesn't belong in this PR) to confirm `repo_owner`/`repo_name` actually show up with the expected shape, including the `bettercalauan` pinned-ref entry. Did **not** visually verify the rendered page (skeleton animation, hover title, hidden-row/pagination interplay, hover-underline styling) in an actual browser — recommend a manual look at the live Pages build after merge, same as #134's own flagged gap.
- **Judgment call — caching 404s.** Not explicitly required by the AC, but without it a dead/renamed/private repo would be re-requested on every single page view forever, which works against the whole point of the TTL as "the real quota control." Cached with the same 7-day treatment as the oldest commit-age band.
- **This PR does not merge on its own** — it depends on #163 having landed (or at least the `main` → `main-pages` auto-sync having run) for `lgu.repo_owner`/`lgu.repo_name` to exist in `_data/lgus.yml`. Until then, `{% if lgu.repo_owner %}` is simply false for every row and the feature renders as a no-op (safe, but inert).

## Fixed in review

- **Merge-conflict risk**: this PR and #163 independently added a file at `scripts/test-repo-activity.js` with unrelated content. `sync-to-pages.yml` does a real `git merge origin/main` into `main-pages` on every push (not a selective copy), so once both landed the next sync would hard-conflict on that path and block the automated `_data/` regen until a human resolved it by hand. Renamed this side to `scripts/test-repo-activity-site.js`; #163 renamed its side to `scripts/test-repo-activity-data.js`. Caught by Reviewer162, verified with `git merge-tree`.
- The regex bug in `parseRepoCell` (greedy `/tree/<ref>` capture) was fixed in #163 — nothing to change here, but flagging since this PR's own notes reference that code.
