### PR TITLE
fix: render nothing, not a dash, when repository activity can't be fetched

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -259,10 +259,16 @@ main tr:last-child td {
    prototype/repo-activity-ui. A terminal fetch failure (rate-limited,
    network error, 404) is the one path that deliberately opts OUT of that
    reservation via `.repo-activity-empty` (Jan, 2026-08-10) — it renders
-   nothing, so the row must read identically to one with no repo link at
+   nothing, so the row should read identically to one with no repo link at
    all, which means the space needs to collapse, not stay reserved. That
    one case DOES reflow after the skeleton; every other path stays
-   reflow-free. */
+   reflow-free.
+   Collapsing this span is NOT sufficient on its own: index.md still emits
+   a build-time `<br>` before this element whenever repo_owner is set, and
+   that `<br>` forces a line break regardless of the span's own height.
+   assets/js/repo-activity.js's renderEmpty() additionally sets that
+   preceding `<br>`'s `display: none` at the same time it adds this class —
+   the two only add up to "no repo link at all" together. */
 .repo-activity {
   display: inline-block;
   min-height: 1.1rem;

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -256,7 +256,13 @@ main tr:last-child td {
    `.repo-activity` reserves its final height from the start via min-height
    on an inline-block, so injecting the loading skeleton, then the real
    value, never reflows the table — see DESIGN.md on
-   prototype/repo-activity-ui. */
+   prototype/repo-activity-ui. A terminal fetch failure (rate-limited,
+   network error, 404) is the one path that deliberately opts OUT of that
+   reservation via `.repo-activity-empty` (Jan, 2026-08-10) — it renders
+   nothing, so the row must read identically to one with no repo link at
+   all, which means the space needs to collapse, not stay reserved. That
+   one case DOES reflow after the skeleton; every other path stays
+   reflow-free. */
 .repo-activity {
   display: inline-block;
   min-height: 1.1rem;
@@ -265,13 +271,13 @@ main tr:last-child td {
   color: var(--color-gray-600);
 }
 
+.repo-activity-empty {
+  min-height: 0;
+}
+
 .repo-activity time {
   border-bottom: 1px dotted var(--color-gray-400);
   cursor: help;
-}
-
-.repo-activity-none {
-  color: var(--color-gray-500);
 }
 
 .repo-activity-skeleton {

--- a/assets/js/repo-activity.js
+++ b/assets/js/repo-activity.js
@@ -6,9 +6,10 @@
 // This is a plain script (no bundler/build step on this branch), so it's
 // wrapped in an IIFE and attaches nothing to `window` except through the
 // DOM it renders into. The handful of pure functions (bucket/exactDate/
-// ttlMs/isFresh) are exported via `module.exports` when running under
-// Node, purely so scripts/test-repo-activity.js can exercise them with
-// zero dependencies — that branch of the export never runs in the browser.
+// ttlMs/isFresh/renderEmpty) are exported via `module.exports` when running
+// under Node, purely so scripts/test-repo-activity-site.js can exercise them
+// with zero dependencies — that branch of the export never runs in the
+// browser.
 (function () {
     'use strict';
 
@@ -46,6 +47,25 @@
 
     function exactDate(iso) {
         return new Date(iso).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+    }
+
+    // Terminal-failure rendering: rate-limited, network error, 404, or any
+    // other case where a value could not be obtained. Clears the cell and
+    // adds a modifier class that collapses `.repo-activity`'s min-height
+    // reservation, so the row reads identically to one with no repo link at
+    // all — no "—" placeholder sitting off-centre next to the GitHub link
+    // (Jan, 2026-08-10, overriding #162's original "renders a neutral —"
+    // acceptance criterion). The min-height reservation still holds for the
+    // loading→value path (that's what keeps the skeleton-then-value swap
+    // reflow-free); collapsing it only for this state means a row that
+    // fails after showing its skeleton DOES reflow — an accepted trade-off.
+    //
+    // A pure DOM-shape function (only touches `.textContent` and
+    // `.classList.add`), so it's exercised under Node with a plain mock
+    // object in scripts/test-repo-activity-site.js — no real DOM needed.
+    function renderEmpty(el) {
+        el.textContent = '';
+        el.classList.add('repo-activity-empty');
     }
 
     // Cache TTL as a function of the *commit's* age, not the cache entry's
@@ -175,7 +195,7 @@
                         if (!res.ok) {
                             // Rate-limited (403/429) or any other non-ok
                             // status: fall back to stale cache if we have
-                            // one, else render neutral — never surface the
+                            // one, else render blank — never surface the
                             // status code.
                             return cached;
                         }
@@ -190,23 +210,21 @@
                         });
                     })
                     .catch(function () {
-                        // Network error: same neutral fallback as rate-limited.
+                        // Network error: same blank fallback as rate-limited.
                         return cached;
                     });
             }
 
-            // ---- rendering: three states, matching prototype.html. The
-            // observed/handled element (`.repo-activity[data-repo]`) IS the
-            // line to fill — a sibling of the repo link after a <br>, not a
-            // wrapper around it, so kramdown's markdown parsing of
-            // {{ lgu.repo }} is never touched by this script. ----
+            // ---- rendering: three states. The observed/handled element
+            // (`.repo-activity[data-repo]`) IS the line to fill — a sibling
+            // of the repo link after a <br>, not a wrapper around it, so
+            // kramdown's markdown parsing of {{ lgu.repo }} is never
+            // touched by this script. The terminal-failure state
+            // (renderEmpty) is defined above as a pure function so it can
+            // be unit tested. ----
 
             function renderLoading(el) {
                 el.innerHTML = '<span class="repo-activity-skeleton" aria-hidden="true"></span>';
-            }
-
-            function renderNone(el) {
-                el.innerHTML = '<span class="repo-activity-none">—</span>';
             }
 
             function renderValue(el, iso) {
@@ -227,7 +245,7 @@
                 // Fast path: a fresh cache entry needs no network at all —
                 // satisfies "repeat visits within the TTL make no request."
                 if (cached && isFresh(cached)) {
-                    if (cached.notFound) renderNone(el); else renderValue(el, cached.pushedAt);
+                    if (cached.notFound) renderEmpty(el); else renderValue(el, cached.pushedAt);
                     return;
                 }
 
@@ -237,7 +255,7 @@
                 var repo = slug.slice(slashIndex + 1);
                 fetchActivity(owner, repo).then(function (entry) {
                     if (!entry || entry.notFound || !entry.pushedAt) {
-                        renderNone(el);
+                        renderEmpty(el);
                         return;
                     }
                     renderValue(el, entry.pushedAt);
@@ -281,6 +299,6 @@
     }
 
     if (typeof module !== 'undefined' && module.exports) {
-        module.exports = { bucket: bucket, exactDate: exactDate, ttlMs: ttlMs, isFresh: isFresh };
+        module.exports = { bucket: bucket, exactDate: exactDate, ttlMs: ttlMs, isFresh: isFresh, renderEmpty: renderEmpty };
     }
 })();

--- a/assets/js/repo-activity.js
+++ b/assets/js/repo-activity.js
@@ -60,12 +60,24 @@
     // reflow-free); collapsing it only for this state means a row that
     // fails after showing its skeleton DOES reflow — an accepted trade-off.
     //
-    // A pure DOM-shape function (only touches `.textContent` and
-    // `.classList.add`), so it's exercised under Node with a plain mock
-    // object in scripts/test-repo-activity-site.js — no real DOM needed.
+    // Collapsing the span alone is NOT enough: index.md emits a build-time
+    // `<br>` before `.repo-activity` whenever `repo_owner` is set — it knows
+    // nothing about a runtime fetch failure, so it still forces a line
+    // break and generates a line box at the parent's line-height even with
+    // the span itself at zero height. `display: none` on that preceding
+    // `<br>` suppresses the break in every current engine, which is what
+    // actually gets the cell back to a single line — the span collapse
+    // alone only removed its own reserved height.
+    //
+    // A pure DOM-shape function (only touches `.textContent`,
+    // `.classList.add`, `.previousSibling`, and a style property), so it's
+    // exercised under Node with a plain mock object in
+    // scripts/test-repo-activity-site.js — no real DOM needed.
     function renderEmpty(el) {
         el.textContent = '';
         el.classList.add('repo-activity-empty');
+        var prev = el.previousSibling;
+        if (prev && prev.nodeName === 'BR') prev.style.display = 'none';
     }
 
     // Cache TTL as a function of the *commit's* age, not the cache entry's

--- a/scripts/test-repo-activity-site.js
+++ b/scripts/test-repo-activity-site.js
@@ -25,7 +25,7 @@
 // same path, unrelated content, guaranteed conflict otherwise.
 
 const assert = require('assert');
-const { bucket, exactDate, ttlMs, isFresh } = require('../assets/js/repo-activity.js');
+const { bucket, exactDate, ttlMs, isFresh, renderEmpty } = require('../assets/js/repo-activity.js');
 
 let assertions = 0;
 function check(condition, message) {
@@ -99,6 +99,36 @@ check(isFresh({}, NOW) === false, 'a malformed cache entry (no fetchedAt) is nev
     const notFound = { notFound: true, fetchedAt: NOW };
     check(isFresh(notFound, NOW + 6 * DAY_MS) === true, 'a cached 404 result stays fresh for up to 7 days');
     check(isFresh(notFound, NOW + 8 * DAY_MS) === false, 'a cached 404 result goes stale after 7 days, so it gets re-checked eventually');
+}
+
+// --- renderEmpty: terminal-failure rendering (blank, not "—") -----------
+//
+// Rate-limited, network error, 404, or any other unfetchable case (Jan,
+// 2026-08-10, overriding #162's original "renders a neutral —" AC — the
+// dash sat off-centre next to the GitHub link). A minimal mock element
+// stands in for a real DOM node — renderEmpty only touches .textContent
+// and .classList.add, so no jsdom/browser dependency is needed here.
+function mockRepoActivityEl(initialText) {
+    const classes = new Set();
+    return {
+        textContent: initialText,
+        classList: { add: (c) => classes.add(c), has: (c) => classes.has(c) },
+        _classes: classes,
+    };
+}
+
+{
+    const el = mockRepoActivityEl('');
+    renderEmpty(el);
+    check(el.textContent === '', 'renderEmpty leaves the cell with no text content — no "—" placeholder');
+    check(el.classList.has('repo-activity-empty'), 'renderEmpty adds the repo-activity-empty modifier class, so CSS can collapse the min-height reservation');
+}
+{
+    // Simulates the skeleton-then-failure path: loading left markup behind,
+    // renderEmpty must still fully clear it, not just append.
+    const el = mockRepoActivityEl('<span class="repo-activity-skeleton" aria-hidden="true"></span>');
+    renderEmpty(el);
+    check(el.textContent === '', 'renderEmpty clears prior skeleton content, not just appends to it');
 }
 
 console.log(`✅ ${assertions} assertions passed.`);

--- a/scripts/test-repo-activity-site.js
+++ b/scripts/test-repo-activity-site.js
@@ -106,13 +106,15 @@ check(isFresh({}, NOW) === false, 'a malformed cache entry (no fetchedAt) is nev
 // Rate-limited, network error, 404, or any other unfetchable case (Jan,
 // 2026-08-10, overriding #162's original "renders a neutral —" AC — the
 // dash sat off-centre next to the GitHub link). A minimal mock element
-// stands in for a real DOM node — renderEmpty only touches .textContent
-// and .classList.add, so no jsdom/browser dependency is needed here.
-function mockRepoActivityEl(initialText) {
+// stands in for a real DOM node — renderEmpty only touches .textContent,
+// .classList.add, and .previousSibling (+ that sibling's .style.display),
+// so no jsdom/browser dependency is needed here.
+function mockRepoActivityEl(initialText, previousSibling) {
     const classes = new Set();
     return {
         textContent: initialText,
         classList: { add: (c) => classes.add(c), has: (c) => classes.has(c) },
+        previousSibling: previousSibling === undefined ? null : previousSibling,
         _classes: classes,
     };
 }
@@ -129,6 +131,36 @@ function mockRepoActivityEl(initialText) {
     const el = mockRepoActivityEl('<span class="repo-activity-skeleton" aria-hidden="true"></span>');
     renderEmpty(el);
     check(el.textContent === '', 'renderEmpty clears prior skeleton content, not just appends to it');
+}
+{
+    // The real DOM shape: index.md always emits a <br> immediately before
+    // .repo-activity when repo_owner is set. That <br> is decided at build
+    // time and knows nothing about a runtime fetch failure, so collapsing
+    // the span's own height alone still leaves a forced line break and a
+    // second line box. renderEmpty must also hide that <br>, or the cell
+    // stays two lines tall and the GitHub link stays off-centre.
+    const br = { nodeName: 'BR', style: {} };
+    const el = mockRepoActivityEl('', br);
+    renderEmpty(el);
+    check(br.style.display === 'none', 'renderEmpty hides a preceding <br> so it no longer forces a line break');
+}
+{
+    // previousSibling can be a text node (e.g. surrounding whitespace) —
+    // renderEmpty must not touch it or throw.
+    const textNode = { nodeName: '#text', data: ' ' };
+    const el = mockRepoActivityEl('', textNode);
+    let threw = false;
+    try { renderEmpty(el); } catch (e) { threw = true; }
+    check(threw === false, 'renderEmpty does not throw when previousSibling is a text node');
+    check(textNode.style === undefined, 'renderEmpty leaves a non-BR previousSibling untouched');
+}
+{
+    // previousSibling can be null (first child, or no siblings at all) —
+    // renderEmpty must not throw.
+    const el = mockRepoActivityEl('', null);
+    let threw = false;
+    try { renderEmpty(el); } catch (e) { threw = true; }
+    check(threw === false, 'renderEmpty does not throw when previousSibling is null');
 }
 
 console.log(`✅ ${assertions} assertions passed.`);


### PR DESCRIPTION
## What

The repository-activity cell (#162) showed a neutral `—` whenever the last-updated fetch failed — rate-limited, network error, or 404. Jan's call: the dash sits off-centre next to the GitHub link; with nothing rendered the link centres properly. This is an explicit override of #162's original acceptance criterion ("Rate-limited, network error, and 404 all render a neutral `—`") — noted here, not silently dropped.

## Change

`assets/js/repo-activity.js`:
- Renamed `renderNone` to `renderEmpty`. It now clears the cell's content entirely instead of writing a `<span class="repo-activity-none">—</span>`.
- **Also hides the preceding `<br>`.** `index.md` emits `{{ lgu.repo }}<br><span class="repo-activity" data-repo="...">` at build time, gated only on `repo_owner` being set — it knows nothing about a runtime fetch failure. So collapsing just the span's height was not enough: the `<br>` still forced a line break and generated its own line box at the parent's line-height, leaving the cell two lines tall and the GitHub link off-centre in the upper half — the exact symptom this PR is meant to fix. `renderEmpty` now also sets `previousSibling.style.display = 'none'` when that sibling is a `<br>` (guarded on `nodeName === 'BR'`, since `previousSibling` can be a text node or null). `display: none` on a `<br>` suppresses the break in every current engine.
- Pulled `renderEmpty` out to a pure, DOM-shape function (top-level, not nested in the browser-only closure) — it only touches `.textContent`, `.classList.add`, and `.previousSibling`/`.style.display`, so it's testable under Node with a mock element, same pattern as the existing `bucket`/`exactDate`/`ttlMs`/`isFresh` exports.
- Still never surfaces an error message or status code — unchanged.
- Loading state (skeleton) is untouched — only the terminal failure state goes blank.

`assets/css/style.css`:
- Added a `.repo-activity-empty` modifier class (`min-height: 0`) and applies it in `renderEmpty`.
- Removed the now-unused `.repo-activity-none` rule.
- Updated the block comment to state plainly that collapsing the span alone is not sufficient — the `<br>` suppression in JS is required too.

### The min-height / centring trade-off

`.repo-activity` reserves a `min-height: 1.1rem` so the loading-skeleton-then-value swap never reflows the table. That reservation, plus the always-emitted `<br>`, is what worked against this fix. `renderEmpty` now opts the failure case out of both: the span collapses via `.repo-activity-empty`, and the preceding `<br>` is hidden — together they should get the cell back to a single line, matching a row with no repo link at all (`index.md`'s `{% if lgu.repo_owner %}` guard means that row never emits a `<br>` or `.repo-activity` span in the first place).

**Consequence, stated plainly:** a row that fails to fetch now collapses after its skeleton — that IS a reflow. #162's AC said "a loading skeleton occupies the line's final height, so filling it in causes no reflow." That still holds for the success path (skeleton → value, no reflow). It no longer holds for the failure path (skeleton → blank, collapses/reflows). This is the accepted trade for the centring fix, per Jan.

**Unverified in a real browser:** no ruby/bundler in this environment, so `bundle exec jekyll build` was never run and the centring claim was never visually confirmed — it's reasoned from the DOM/CSS mechanics (`display:none` on a `<br>` suppressing its line box), not observed. Flagging this as a real gap, not glossing over it.

## Tests

`scripts/test-repo-activity-site.js` (was 31/31, asserting only the pure bucket/exactDate/ttlMs/isFresh functions — it never actually asserted the `—` string, since rendering lives in the DOM-only closure). Added:
- `renderEmpty` clears `.textContent` to `''` (no `—` placeholder).
- `renderEmpty` adds the `repo-activity-empty` class.
- `renderEmpty` fully clears prior skeleton markup, not just appends.
- `renderEmpty` hides a preceding `<br>` (`nodeName === 'BR'`).
- `renderEmpty` leaves a text-node `previousSibling` untouched and doesn't throw.
- `renderEmpty` doesn't throw when `previousSibling` is `null`.

Now **38/38**, run for real: `node scripts/test-repo-activity-site.js`.

## Gate

- `node --check` on `assets/js/repo-activity.js` and `scripts/test-repo-activity-site.js` — pass.
- `node scripts/test-repo-activity-site.js` — 38/38 pass.
- No ruby/bundler available in this environment — `bundle exec jekyll build` was not run, so the centring result is not visually verified (see above). Stated verification gap, same as prior PRs on this repo.

No GitHub issue for this — direct request from Jan, overriding part of #162's AC. Companion PR (data side, unrelated fix): #165 (merged).