### PR TITLE
feat(crawl): report the specific rule that made a portal ineligible

### DIFF
--- a/scripts/crawl-lgu-meta.js
+++ b/scripts/crawl-lgu-meta.js
@@ -34,6 +34,145 @@ function isBoilerplate(title, description) {
     );
 }
 
+// --- Ineligibility reasons -------------------------------------------------
+//
+// Every rule that can keep an Entry out of the Featured pool reports why, as
+// a { summaries, message } pair:
+//
+//   summaries — one or more variable-free phrases naming the rule(s) that
+//               failed. These are the grouping keys for the end-of-run tally,
+//               so they must never embed a URL, byte count, status code or
+//               content type. A portal missing two meta fields reports two
+//               summaries, so each field's total stays readable as one number
+//               rather than splitting across every combination it appeared in.
+//   message   — the single per-portal log line, which does carry those
+//               specifics.
+//
+// Before this, all of these paths returned a bare null and main() printed one
+// static "incomplete, boilerplate, or robots-disallowed" line for every one of
+// them — which named three causes out of seven and made a missing meta tag
+// indistinguishable from a 404 on the og:image.
+function reason(summaries, message) {
+    const list = Array.isArray(summaries) ? summaries : [summaries];
+    return { summaries: list, message: message || list.join('; ') };
+}
+
+// extractMeta() resolves each field through its fallback chain first, so a
+// blank here means *every* source for that field was absent — name them all,
+// otherwise the log sends the reader looking for an og: tag they may have
+// deliberately skipped in favour of the plain HTML one.
+const META_FIELD_SOURCES = [
+    ['image', 'og:image'],
+    ['title', 'og:title/<title>'],
+    ['description', 'og:description/meta[name=description]'],
+];
+
+function missingMetaReason({ title, description, image }) {
+    const values = { title, description, image };
+    const missing = META_FIELD_SOURCES.filter(([field]) => !values[field]).map(([, label]) => label);
+    if (missing.length === 0) return null;
+    // One summary per absent field: a portal missing both the image and the
+    // description counts towards each field's own tally row, so "how many
+    // portals have no og:image at all" is a single number in the summary.
+    return reason(
+        missing.map((label) => `missing ${label}`),
+        `missing ${missing.join(' + ')}`,
+    );
+}
+
+function boilerplateReason(title, description) {
+    // isBoilerplate() stays the single gate (see its comment above) so a future
+    // template revision only has to be made there; the per-field checks below
+    // exist purely to tell the operator which field tripped it.
+    if (!isBoilerplate(title, description)) return null;
+
+    const matched = [];
+    if (normalizeWhitespace(title) === normalizeWhitespace(BOILERPLATE_TITLE)) matched.push('title');
+    if (normalizeWhitespace(description) === normalizeWhitespace(BOILERPLATE_DESCRIPTION)) {
+        matched.push('description');
+    }
+    const generic = "BetterGov.ph's generic template copy";
+    return reason(
+        'boilerplate BetterGov.ph template copy',
+        // A rule added to isBoilerplate() but not mirrored here still reports —
+        // just without naming the field.
+        matched.length === 0
+            ? `title/description is still ${generic}`
+            : `${matched.join(' and ')} ${matched.length > 1 ? 'are' : 'is'} still ${generic}`,
+    );
+}
+
+function formatBytes(bytes) {
+    return `${(bytes / 1024).toFixed(1)}KB`;
+}
+
+// The og:image is fetched separately from the page, so it has four distinct
+// ways to fail. The page itself answering fine means none of them make the
+// portal "unreachable" — they are all metadata-quality rejections.
+function imageRejectionReason({ imageUrl, fetchError, statusCode, contentType, byteLength, truncatedOversize }) {
+    // Tested for presence, not truthiness: an Error carrying an empty message
+    // still means the fetch failed, and falling through would misreport it as
+    // a content-type problem — exactly the misattribution this reporting
+    // exists to remove.
+    if (fetchError !== undefined && fetchError !== null) {
+        const detail = String(fetchError) || 'no error detail available';
+        return reason('og:image could not be fetched', `og:image could not be fetched (${imageUrl}): ${detail}`);
+    }
+    if (!Number.isFinite(statusCode)) {
+        return reason('og:image response was unusable', `og:image returned no usable HTTP status (${imageUrl})`);
+    }
+    if (statusCode >= 400 || statusCode < 200) {
+        return reason('og:image returned an HTTP error', `og:image returned HTTP ${statusCode} (${imageUrl})`);
+    }
+    const normalizedType = (contentType || '').toLowerCase();
+    if (!normalizedType.startsWith('image/')) {
+        return reason(
+            'og:image is not an image',
+            `og:image served as ${normalizedType ? `"${normalizedType}"` : 'no Content-Type'} (${imageUrl})`,
+        );
+    }
+    if (truncatedOversize || byteLength > IMAGE_SIZE_CEILING_BYTES) {
+        // A truncated fetch stopped reading at the ceiling, so the real size is
+        // unknown — say so rather than reporting the ceiling as the size.
+        const ceiling = formatBytes(IMAGE_SIZE_CEILING_BYTES);
+        return reason(
+            'og:image exceeds the size ceiling',
+            truncatedOversize
+                ? `og:image exceeds the ${ceiling} ceiling (truncated mid-download) (${imageUrl})`
+                : `og:image is ${formatBytes(byteLength)}, over the ${ceiling} ceiling (${imageUrl})`,
+        );
+    }
+    return null;
+}
+
+// Groups the run's rejections by summary so a systemic problem (say, twelve
+// portals with no og:image at all) reads as one line instead of needing the
+// whole per-portal log scrolled and counted by hand. Takes one entry per
+// rejected portal — each being that portal's list of summaries — so the
+// headline count stays a portal count even though a portal can fail two rules
+// at once, in which case it contributes to both tally rows.
+function formatIneligibleSummary(rejections) {
+    if (rejections.length === 0) return '';
+
+    const counts = new Map();
+    for (const summaries of rejections) {
+        for (const summary of new Set(summaries)) {
+            counts.set(summary, (counts.get(summary) || 0) + 1);
+        }
+    }
+
+    const rows = [...counts.entries()].sort(
+        (a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0),
+    );
+    const labelWidth = Math.max(...rows.map(([label]) => label.length));
+    const countWidth = Math.max(...rows.map(([, count]) => String(count).length));
+
+    return [
+        `Ineligible (${rejections.length}):`,
+        ...rows.map(([label, count]) => `  ${label.padEnd(labelWidth)}  ${String(count).padStart(countWidth)}`),
+    ].join('\n');
+}
+
 // Escape a value for safe embedding inside a double-quoted YAML scalar.
 function yamlStr(value) {
     return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
@@ -249,15 +388,20 @@ function extractDomainLink(rawCell) {
     return { label: bare, url: /^https?:\/\//i.test(bare) ? bare : `https://${bare}` };
 }
 
-// Crawls one Entry's portal and returns a complete lgu-meta row, or null if
-// the portal is reachable but does not meet the completeness/quality bar
-// (#122, #125, #127). Throws PortalUnreachableError if the portal itself
-// looks down — callers use that to decide whether to preserve the previous
-// row instead of dropping it.
+// Crawls one Entry's portal and returns { row, reason }: a complete lgu-meta
+// row when the portal clears the bar, or `row: null` plus the specific
+// { summary, message } rejection when it is reachable but does not meet the
+// completeness/quality bar (#122, #125, #127). Throws PortalUnreachableError
+// if the portal itself looks down — callers use that to decide whether to
+// preserve the previous row instead of dropping it.
 async function crawlEntry(entry, displayDomain, origin) {
+    const rejected = (why) => ({ row: null, reason: why });
+
     const robots = await checkRobots(origin);
     if (robots.disallowed) {
-        return null;
+        return rejected(
+            reason('robots.txt disallows our crawler', `robots.txt at ${origin} disallows ${USER_AGENT}`),
+        );
     }
     if (robots.crawlDelaySeconds > 0) {
         await sleep(robots.crawlDelaySeconds * 1000);
@@ -276,14 +420,16 @@ async function crawlEntry(entry, displayDomain, origin) {
     const html = pageRes.body.toString('utf8');
     const { title, description, image } = extractMeta(html);
 
-    if (!title || !description || !image) {
-        // Mechanically incomplete — no fallback (#125), no row.
-        return null;
+    // Mechanically incomplete — no fallback (#125), no row.
+    const incomplete = missingMetaReason({ title, description, image });
+    if (incomplete) {
+        return rejected(incomplete);
     }
 
-    if (isBoilerplate(title, description)) {
-        // Complete but not "about" the LGU (#122's quality floor) — no row.
-        return null;
+    // Complete but not "about" the LGU (#122's quality floor) — no row.
+    const boilerplate = boilerplateReason(title, description);
+    if (boilerplate) {
+        return rejected(boilerplate);
     }
 
     if (robots.crawlDelaySeconds > 0) {
@@ -297,27 +443,30 @@ async function crawlEntry(entry, displayDomain, origin) {
     } catch (err) {
         // The image failing to load is a metadata-quality problem, not the
         // whole portal being down — the page itself answered fine.
-        return null;
+        return rejected(imageRejectionReason({ imageUrl, fetchError: err.message }));
     }
 
-    if (imageRes.statusCode >= 400 || imageRes.statusCode < 200) {
-        return null;
-    }
-    const imageContentType = (imageRes.headers['content-type'] || '').toLowerCase();
-    if (!imageContentType.startsWith('image/')) {
-        return null;
-    }
-    if (imageRes.truncatedOversize || imageRes.body.length > IMAGE_SIZE_CEILING_BYTES) {
-        return null;
+    const imageRejection = imageRejectionReason({
+        imageUrl,
+        statusCode: imageRes.statusCode,
+        contentType: imageRes.headers['content-type'] || '',
+        byteLength: imageRes.body.length,
+        truncatedOversize: imageRes.truncatedOversize,
+    });
+    if (imageRejection) {
+        return rejected(imageRejection);
     }
 
     return {
-        name: entry.name,
-        domain: displayDomain,
-        image: imageUrl,
-        title,
-        description,
-        order_key: sha1First8(displayDomain),
+        row: {
+            name: entry.name,
+            domain: displayDomain,
+            image: imageUrl,
+            title,
+            description,
+            order_key: sha1First8(displayDomain),
+        },
+        reason: null,
     };
 }
 
@@ -383,22 +532,34 @@ async function main() {
 
     const previous = parseExistingLguMeta(LGU_META_PATH);
     const rows = [];
+    // One entry per portal kept out of the pool — each entry being that
+    // portal's summaries — tallied at the end of the run.
+    const rejections = [];
 
     for (const entry of candidates) {
         const { label: displayDomain, url: origin } = extractDomainLink(entry.domain);
         try {
-            const row = await crawlEntry(entry, displayDomain, origin);
+            const { row, reason: rejection } = await crawlEntry(entry, displayDomain, origin);
             if (row) {
                 rows.push(row);
                 console.log(`  ✅ ${displayDomain} — featured row generated`);
             } else {
-                console.log(`  ⛔ ${displayDomain} — ineligible (incomplete, boilerplate, or robots-disallowed)`);
+                // A rejection with no reason would be a bug in this script, not
+                // a fact about the portal — say so rather than dereferencing
+                // null and having the catch below blame the network for it.
+                const described = rejection || reason('rejected without a stated reason (bug)');
+                rejections.push(described.summaries);
+                console.log(`  ⛔ ${displayDomain} — ineligible: ${described.message}`);
             }
         } catch (err) {
-            if (err instanceof PortalUnreachableError && previous.has(displayDomain)) {
+            if (!(err instanceof PortalUnreachableError)) {
+                rejections.push(['crawl error (not a portal problem)']);
+                console.log(`  ⛔ ${displayDomain} — crawl error: ${err.stack || err.message}`);
+            } else if (previous.has(displayDomain)) {
                 rows.push(previous.get(displayDomain));
                 console.log(`  ⚠️  ${displayDomain} — unreachable this run (${err.message}); kept previous row`);
             } else {
+                rejections.push(['unreachable, with no previous row to keep']);
                 console.log(`  ⛔ ${displayDomain} — unreachable and no previous row (${err.message})`);
             }
         }
@@ -410,6 +571,11 @@ async function main() {
     }
     fs.writeFileSync(LGU_META_PATH, formatLguMetaYaml(rows));
     console.log(`🎉 Featured pool: ${rows.length} eligible portal(s). Written to ${LGU_META_PATH}`);
+
+    const summaryBlock = formatIneligibleSummary(rejections);
+    if (summaryBlock) {
+        console.log(`\n${summaryBlock}`);
+    }
 }
 
 if (require.main === module) {
@@ -421,11 +587,17 @@ if (require.main === module) {
 
 module.exports = {
     USER_AGENT,
+    PortalUnreachableError,
+    crawlEntry,
     IMAGE_SIZE_CEILING_BYTES,
     BOILERPLATE_DESCRIPTION,
     BOILERPLATE_TITLE,
     normalizeWhitespace,
     isBoilerplate,
+    missingMetaReason,
+    boilerplateReason,
+    imageRejectionReason,
+    formatIneligibleSummary,
     sha1First8,
     extractMeta,
     parseTagAttrs,

--- a/scripts/test-crawl-reporting.js
+++ b/scripts/test-crawl-reporting.js
@@ -1,0 +1,214 @@
+// Zero-dependency integration test for crawlEntry(): proves that each way a
+// portal can be kept out of the Featured pool reaches the log as its own
+// specific reason, end to end, against a real HTTP server. Run with:
+//
+//   node scripts/test-crawl-reporting.js
+//
+// It exits non-zero on any failure.
+//
+// Why this exists alongside test-featured-eligibility.js: that file tests the
+// reason helpers in isolation, which leaves the wiring — crawlEntry picking
+// the right helper for the branch it is in, and passing it the right values —
+// untested. Since the whole point of this reporting is that the log says the
+// true cause, a mis-wired branch (a network failure reported as a
+// content-type problem, say) would be exactly the bug that matters and the
+// unit tests would still pass. Two loopback servers on ephemeral ports stand
+// in for the portals: no network access, no fixtures on disk, nothing to keep
+// in sync with a live site.
+
+const assert = require('assert');
+const http = require('http');
+const {
+    IMAGE_SIZE_CEILING_BYTES,
+    BOILERPLATE_TITLE,
+    PortalUnreachableError,
+    crawlEntry,
+} = require('./crawl-lgu-meta.js');
+
+let failures = 0;
+const tests = [];
+function test(name, fn) {
+    tests.push({ name, fn });
+}
+
+function page({ title = 'Better Fixture', description = 'The transparency portal of Fixture.', image = '/img/ok.png' }) {
+    return [
+        title === null ? '' : `<title>${title}</title>`,
+        description === null ? '' : `<meta name="description" content="${description}">`,
+        image === null ? '' : `<meta property="og:image" content="${image}">`,
+    ].join('');
+}
+
+// Every path the crawler can take, keyed by the URL the fixture serves it on.
+const ROUTES = {
+    '/good/': page({}),
+    '/no-image/': page({ image: null }),
+    '/no-title/': page({ title: null }),
+    '/nothing/': page({ title: null, description: null, image: null }),
+    '/boilerplate/': page({ title: BOILERPLATE_TITLE }),
+    '/image-404/': page({ image: '/img/gone.png' }),
+    '/image-html/': page({ image: '/img/not-an-image' }),
+    '/image-big/': page({ image: '/img/big.png' }),
+    // Port 1 is reserved and never listening, so this reproduces a refused
+    // connection on the image without needing an offline host.
+    '/image-dead/': page({ image: 'http://127.0.0.1:1/img/og.png' }),
+};
+
+function startPortalServer() {
+    return new Promise((resolve) => {
+        const server = http.createServer((req, res) => {
+            if (req.url === '/robots.txt') {
+                res.writeHead(404).end();
+            } else if (req.url === '/img/ok.png') {
+                res.writeHead(200, { 'content-type': 'image/png' }).end(Buffer.alloc(1024));
+            } else if (req.url === '/img/big.png') {
+                res.writeHead(200, { 'content-type': 'image/png' }).end(
+                    Buffer.alloc(IMAGE_SIZE_CEILING_BYTES + 2048),
+                );
+            } else if (req.url === '/img/not-an-image') {
+                res.writeHead(200, { 'content-type': 'text/html' }).end('<p>not an image</p>');
+            } else if (req.url === '/down/') {
+                res.writeHead(503).end();
+            } else if (req.url in ROUTES) {
+                res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' }).end(ROUTES[req.url]);
+            } else {
+                res.writeHead(404).end();
+            }
+        });
+        server.listen(0, '127.0.0.1', () => resolve(server));
+    });
+}
+
+// A separate origin, because robots.txt is per-origin and a blanket disallow
+// here would take every other case with it.
+function startBlockedServer() {
+    return new Promise((resolve) => {
+        const server = http.createServer((req, res) => {
+            if (req.url === '/robots.txt') {
+                res.writeHead(200, { 'content-type': 'text/plain' }).end('User-agent: *\nDisallow: /\n');
+            } else {
+                res.writeHead(200, { 'content-type': 'text/html' }).end(page({}));
+            }
+        });
+        server.listen(0, '127.0.0.1', () => resolve(server));
+    });
+}
+
+async function main() {
+    const portal = await startPortalServer();
+    const blocked = await startBlockedServer();
+    const origin = (path) => `http://127.0.0.1:${portal.address().port}${path}`;
+    const blockedOrigin = `http://127.0.0.1:${blocked.address().port}/`;
+
+    const crawl = (path) => crawlEntry({ name: 'Fixture LGU' }, 'fixture.test', origin(path));
+
+    // A rejection must always be reportable: main() prints reason.message and
+    // tallies reason.summaries, so a null or half-built reason would surface as
+    // a crash blamed on the portal.
+    function assertRejected(result, { summaryMatch, messageMatch, messageNotMatch }) {
+        assert.strictEqual(result.row, null, 'expected no row');
+        assert.ok(result.reason, 'a rejection must carry a reason');
+        assert.ok(Array.isArray(result.reason.summaries) && result.reason.summaries.length > 0);
+        const joined = result.reason.summaries.join(' | ');
+        if (summaryMatch) assert.match(joined, summaryMatch);
+        if (messageMatch) assert.match(result.reason.message, messageMatch);
+        if (messageNotMatch) assert.doesNotMatch(result.reason.message, messageNotMatch);
+    }
+
+    test('a complete, original portal yields a row and no reason', async () => {
+        const { row, reason } = await crawl('/good/');
+        assert.strictEqual(reason, null);
+        assert.strictEqual(row.name, 'Fixture LGU');
+        assert.strictEqual(row.title, 'Better Fixture');
+        assert.ok(row.image.endsWith('/img/ok.png'), row.image);
+        assert.ok(row.order_key.length > 0);
+    });
+
+    test('a missing og:image is reported as a missing og:image', async () => {
+        assertRejected(await crawl('/no-image/'), {
+            summaryMatch: /missing og:image/,
+            messageNotMatch: /og:title/,
+        });
+    });
+
+    test('a page with no title at all names the title and its fallback', async () => {
+        assertRejected(await crawl('/no-title/'), { summaryMatch: /og:title/ });
+    });
+
+    test('a page missing every field reports all three, one summary each', async () => {
+        const result = await crawl('/nothing/');
+        assertRejected(result, {});
+        assert.strictEqual(result.reason.summaries.length, 3);
+    });
+
+    test('template copy is reported as boilerplate, naming the field', async () => {
+        assertRejected(await crawl('/boilerplate/'), {
+            summaryMatch: /boilerplate/i,
+            messageMatch: /title/i,
+        });
+    });
+
+    test('a 404 on the og:image reports the status, not a missing tag', async () => {
+        assertRejected(await crawl('/image-404/'), {
+            summaryMatch: /HTTP error/,
+            messageMatch: /404/,
+            messageNotMatch: /missing/,
+        });
+    });
+
+    test('an og:image that is not an image reports the served type', async () => {
+        assertRejected(await crawl('/image-html/'), {
+            summaryMatch: /not an image/,
+            messageMatch: /text\/html/,
+        });
+    });
+
+    test('an oversized og:image reports the ceiling it broke', async () => {
+        assertRejected(await crawl('/image-big/'), {
+            summaryMatch: /size ceiling/,
+            messageMatch: /KB/,
+        });
+    });
+
+    test('an unreachable og:image reports the network error, not a content type', async () => {
+        assertRejected(await crawl('/image-dead/'), {
+            summaryMatch: /could not be fetched/,
+            messageMatch: /ECONNREFUSED/,
+            messageNotMatch: /not an image/,
+        });
+    });
+
+    test('a robots.txt blanket disallow is reported as such', async () => {
+        assertRejected(await crawlEntry({ name: 'Fixture LGU' }, 'blocked.test', blockedOrigin), {
+            summaryMatch: /robots\.txt/,
+            messageMatch: /robots\.txt/,
+        });
+    });
+
+    // The distinction the reporting must not blur: a portal that is down keeps
+    // its previous row (#132), so it throws instead of returning a rejection.
+    test('a portal returning 503 throws PortalUnreachableError, not a rejection', async () => {
+        await assert.rejects(() => crawl('/down/'), PortalUnreachableError);
+    });
+
+    for (const { name, fn } of tests) {
+        try {
+            await fn();
+            console.log(`  ✅ ${name}`);
+        } catch (err) {
+            failures++;
+            console.log(`  ❌ ${name}\n     ${err.message}`);
+        }
+    }
+
+    portal.close();
+    blocked.close();
+    console.log(failures === 0 ? '\n✅ All crawl reporting tests passed.\n' : `\n❌ ${failures} test(s) failed.\n`);
+    process.exit(failures === 0 ? 0 : 1);
+}
+
+console.log('\ncrawlEntry() reporting');
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/scripts/test-featured-eligibility.js
+++ b/scripts/test-featured-eligibility.js
@@ -1,0 +1,285 @@
+// Zero-dependency regression test for the Featured Portal *ineligibility
+// reporting* helpers in crawl-lgu-meta.js. Same shape as
+// test-rotation-index.js: this repo has no package.json / test runner on
+// either branch, so this is a plain Node script using the built-in `assert`
+// module. Run with:
+//
+//   node scripts/test-featured-eligibility.js
+//
+// It exits non-zero on any failure.
+//
+// Why this exists: crawlEntry() used to collapse seven distinct rejection
+// paths (robots disallow, each missing meta field, boilerplate copy, and four
+// separate og:image failures) into a bare `return null`, and main() printed
+// one static line — "ineligible (incomplete, boilerplate, or
+// robots-disallowed)" — for all of them. That line named three causes out of
+// seven, and the og:image fetch error path threw away an `err.message` it
+// already held. An operator reading the Actions log could not tell a missing
+// meta tag from a 404 on the image. These helpers make each rejection say
+// exactly which rule failed, with the offending value, while keeping a
+// variable-free `summary` per failed rule so the end-of-run tally can group
+// them.
+
+const assert = require('assert');
+const {
+    IMAGE_SIZE_CEILING_BYTES,
+    BOILERPLATE_DESCRIPTION,
+    BOILERPLATE_TITLE,
+    missingMetaReason,
+    boilerplateReason,
+    imageRejectionReason,
+    formatIneligibleSummary,
+} = require('./crawl-lgu-meta.js');
+
+let failures = 0;
+function test(name, fn) {
+    try {
+        fn();
+        console.log(`  ✅ ${name}`);
+    } catch (err) {
+        failures++;
+        console.log(`  ❌ ${name}\n     ${err.message}`);
+    }
+}
+
+// A reason is { summaries, message }. Every summary must be free of
+// run-specific values (URLs, byte counts, content types) so identical failures
+// across portals collapse onto one tally row; `message` carries those
+// specifics.
+function assertReasonShape(reason) {
+    assert.ok(reason, 'expected a reason, got null');
+    assert.ok(Array.isArray(reason.summaries), 'summaries must be an array');
+    assert.ok(reason.summaries.length > 0, 'summaries must not be empty');
+    for (const summary of reason.summaries) {
+        assert.strictEqual(typeof summary, 'string');
+        assert.ok(summary.length > 0, 'a summary must not be empty');
+    }
+    assert.strictEqual(typeof reason.message, 'string');
+    assert.ok(reason.message.length > 0, 'message must not be empty');
+}
+
+// Most rules report exactly one summary; joining keeps the assertions below
+// readable without hiding a rule that wrongly reports several.
+function onlySummary(reason) {
+    assert.strictEqual(reason.summaries.length, 1, `expected one summary, got ${reason.summaries.join(' | ')}`);
+    return reason.summaries[0];
+}
+
+console.log('\nmissingMetaReason()');
+
+test('returns null when title, description and image are all present', () => {
+    assert.strictEqual(
+        missingMetaReason({ title: 'Better Solano', description: 'The portal.', image: '/og.png' }),
+        null,
+    );
+});
+
+test('names og:image alone when only the image is missing', () => {
+    const reason = missingMetaReason({ title: 'Better Solano', description: 'The portal.', image: '' });
+    assertReasonShape(reason);
+    const summary = onlySummary(reason);
+    assert.match(summary, /og:image/);
+    assert.doesNotMatch(summary, /og:title/);
+    assert.doesNotMatch(summary, /og:description/);
+});
+
+test('names the title source and its <title> fallback when the title is missing', () => {
+    const reason = missingMetaReason({ title: '', description: 'The portal.', image: '/og.png' });
+    assertReasonShape(reason);
+    assert.match(onlySummary(reason), /og:title.*<title>/);
+});
+
+test('names the description source and its meta fallback when it is missing', () => {
+    const reason = missingMetaReason({ title: 'Better Solano', description: '', image: '/og.png' });
+    assertReasonShape(reason);
+    assert.match(onlySummary(reason), /og:description.*name=description/);
+});
+
+test('names every missing field at once in the log line, not just the first', () => {
+    const reason = missingMetaReason({ title: '', description: '', image: '' });
+    assertReasonShape(reason);
+    assert.match(reason.message, /og:title/);
+    assert.match(reason.message, /og:description/);
+    assert.match(reason.message, /og:image/);
+});
+
+// The tally exists to make a systemic problem read as one number. If a portal
+// missing both the image and the description reported a single combined
+// summary, "how many portals have no og:image" would fragment across every
+// combination it ever appeared in, and the real total would never be shown.
+test('reports one summary per missing field so each field tallies independently', () => {
+    const reason = missingMetaReason({ title: '', description: '', image: '' });
+    assert.strictEqual(reason.summaries.length, 3);
+    const both = missingMetaReason({ title: 'Better Solano', description: '', image: '' });
+    const imageOnly = missingMetaReason({ title: 'Better Solano', description: 'The portal.', image: '' });
+    assert.ok(
+        both.summaries.includes(onlySummary(imageOnly)),
+        'a portal missing two fields must still count towards the og:image row',
+    );
+});
+
+test('a given set of missing fields always yields the same summaries', () => {
+    const a = missingMetaReason({ title: '', description: 'x', image: '' });
+    const b = missingMetaReason({ title: '', description: 'y', image: '' });
+    assert.deepStrictEqual(a.summaries, b.summaries);
+});
+
+console.log('\nboilerplateReason()');
+
+test('returns null for copy that is genuinely about the LGU', () => {
+    assert.strictEqual(boilerplateReason('Better Solano', 'The transparency portal of Solano.'), null);
+});
+
+test('reports the description when the description is the template copy', () => {
+    const reason = boilerplateReason('Better Solano', BOILERPLATE_DESCRIPTION);
+    assertReasonShape(reason);
+    assert.match(reason.message, /description/i);
+});
+
+test('reports the title when the title is the template copy', () => {
+    const reason = boilerplateReason(BOILERPLATE_TITLE, 'The transparency portal of Solano.');
+    assertReasonShape(reason);
+    assert.match(reason.message, /title/i);
+});
+
+test('matches template copy that differs only in whitespace', () => {
+    const spaced = `  ${BOILERPLATE_DESCRIPTION.replace(/ /g, '  ')}  `;
+    assertReasonShape(boilerplateReason('Better Solano', spaced));
+});
+
+console.log('\nimageRejectionReason()');
+
+const OK_IMAGE = {
+    imageUrl: 'https://bettersolano.org/og.png',
+    statusCode: 200,
+    contentType: 'image/png',
+    byteLength: 1024,
+    truncatedOversize: false,
+};
+
+test('returns null for a 200 image/* response inside the size ceiling', () => {
+    assert.strictEqual(imageRejectionReason(OK_IMAGE), null);
+});
+
+test('surfaces the underlying fetch error message instead of discarding it', () => {
+    const reason = imageRejectionReason({ ...OK_IMAGE, fetchError: 'getaddrinfo ENOTFOUND cdn.example' });
+    assertReasonShape(reason);
+    assert.match(reason.message, /getaddrinfo ENOTFOUND cdn\.example/);
+    assert.match(reason.message, /og\.png/);
+    assert.doesNotMatch(onlySummary(reason), /ENOTFOUND/);
+});
+
+test('reports the HTTP status for a non-2xx image response', () => {
+    const reason = imageRejectionReason({ ...OK_IMAGE, statusCode: 404 });
+    assertReasonShape(reason);
+    assert.match(reason.message, /404/);
+    assert.doesNotMatch(onlySummary(reason), /404/);
+});
+
+test('treats an informational/redirect-leftover status below 200 as a failure', () => {
+    assertReasonShape(imageRejectionReason({ ...OK_IMAGE, statusCode: 199 }));
+});
+
+test('reports the served content type when og:image is not an image', () => {
+    const reason = imageRejectionReason({ ...OK_IMAGE, contentType: 'text/html; charset=utf-8' });
+    assertReasonShape(reason);
+    assert.match(reason.message, /text\/html/);
+    assert.doesNotMatch(onlySummary(reason), /text\/html/);
+});
+
+test('reports a missing content type readably rather than as an empty string', () => {
+    const reason = imageRejectionReason({ ...OK_IMAGE, contentType: '' });
+    assertReasonShape(reason);
+    assert.ok(!/""/.test(reason.message), `message should not contain an empty quoted value: ${reason.message}`);
+});
+
+test('reports actual and allowed size when the image is over the ceiling', () => {
+    const reason = imageRejectionReason({ ...OK_IMAGE, byteLength: IMAGE_SIZE_CEILING_BYTES + 1 });
+    assertReasonShape(reason);
+    assert.match(reason.message, /KB/);
+    assert.doesNotMatch(onlySummary(reason), /\d+\s*KB/);
+});
+
+test('rejects a response truncated at the size ceiling', () => {
+    assertReasonShape(imageRejectionReason({ ...OK_IMAGE, byteLength: 10, truncatedOversize: true }));
+});
+
+test('reports the fetch error ahead of the status when both are present', () => {
+    const reason = imageRejectionReason({ ...OK_IMAGE, statusCode: 0, fetchError: 'socket hang up' });
+    assert.match(reason.message, /socket hang up/);
+});
+
+// A socket-level failure can surface as an Error with an empty message. A
+// truthiness check on it falls through to the content-type branch, which then
+// blames the image's Content-Type for what was really a network failure — the
+// exact misattribution this reporting exists to remove.
+test('still reports a fetch failure when the error message is empty', () => {
+    const reason = imageRejectionReason({ imageUrl: OK_IMAGE.imageUrl, fetchError: '' });
+    assertReasonShape(reason);
+    assert.match(onlySummary(reason), /fetch/i);
+    assert.doesNotMatch(reason.message, /Content-Type/i);
+});
+
+test('does not report a missing status as a content-type problem', () => {
+    const reason = imageRejectionReason({ imageUrl: OK_IMAGE.imageUrl });
+    assertReasonShape(reason);
+    assert.doesNotMatch(reason.message, /not an image/i);
+});
+
+console.log('\nformatIneligibleSummary()');
+
+test('returns an empty string when nothing was rejected', () => {
+    assert.strictEqual(formatIneligibleSummary([]), '');
+});
+
+// Input is one entry per rejected portal, each holding that portal's summaries.
+test('counts the total and tallies each distinct summary', () => {
+    const block = formatIneligibleSummary([
+        ['missing og:image'],
+        ['missing og:image'],
+        ['og:image returned an HTTP error'],
+        ['missing og:image'],
+    ]);
+    assert.match(block, /Ineligible \(4\)/);
+    assert.match(block, /missing og:image\s+3/);
+    assert.match(block, /og:image returned an HTTP error\s+1/);
+});
+
+test('counts a portal once in the headline but on every rule row it failed', () => {
+    const block = formatIneligibleSummary([['missing og:image', 'missing og:title/<title>'], ['missing og:image']]);
+    assert.match(block, /Ineligible \(2\)/);
+    assert.match(block, /missing og:image\s+2/);
+    assert.match(block, /missing og:title\/<title>\s+1/);
+});
+
+test('does not double-count a summary repeated within one portal', () => {
+    const block = formatIneligibleSummary([['same rule', 'same rule']]);
+    assert.match(block, /same rule\s+1/);
+});
+
+test('orders tally rows by descending count', () => {
+    const block = formatIneligibleSummary([['rare'], ['common'], ['common'], ['common']]);
+    assert.ok(
+        block.indexOf('common') < block.indexOf('rare'),
+        `expected the 3x row before the 1x row:\n${block}`,
+    );
+});
+
+test('breaks count ties alphabetically so the output is deterministic', () => {
+    const forwards = formatIneligibleSummary([['beta'], ['alpha']]);
+    const backwards = formatIneligibleSummary([['alpha'], ['beta']]);
+    assert.strictEqual(forwards, backwards);
+    assert.ok(forwards.indexOf('alpha') < forwards.indexOf('beta'), forwards);
+});
+
+test('aligns the counts into a column', () => {
+    const block = formatIneligibleSummary([['short'], ['a much longer reason phrase']]);
+    const countColumns = block
+        .split('\n')
+        .filter((line) => /\s\d+$/.test(line))
+        .map((line) => line.lastIndexOf('1'));
+    assert.strictEqual(new Set(countColumns).size, 1, `counts not aligned:\n${block}`);
+});
+
+console.log(failures === 0 ? '\n✅ All eligibility-reporting tests passed.\n' : `\n❌ ${failures} test(s) failed.\n`);
+process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## What

`crawlEntry()` in `scripts/crawl-lgu-meta.js` collapsed **seven** distinct rejection paths into a bare `return null`, and `main()` printed one static line for all of them:

```
⛔ example.org — ineligible (incomplete, boilerplate, or robots-disallowed)
```

That line names three causes out of seven. Reading the Actions log, a maintainer cannot tell a missing meta tag from a 404 on the `og:image`, a non-image `Content-Type`, or an image over the size ceiling — and four of the seven causes are og:image fetch failures that the message never mentions at all. The fetch-error path was the worst case: it caught an `err.message` and discarded it.

| line (before) | real cause | named in the old message? |
|---|---|---|
| 259 | `robots.txt` blanket `Disallow: /` | yes |
| 279 | missing `og:title` / `og:description` / `og:image` (not which) | "incomplete" |
| 284 | boilerplate BetterGov.ph template copy | yes |
| 300 | `og:image` fetch threw — `err.message` **discarded** | no |
| 303 | `og:image` HTTP >= 400 | no |
| 307 | `og:image` `Content-Type` not `image/*` | no |
| 310 | `og:image` over `IMAGE_SIZE_CEILING_BYTES` (400KB) | no |

## How

`crawlEntry()` now returns `{ row, reason }`. A reason carries:

- **`summaries`** — one or more variable-free phrases naming the rule(s) that failed. These are the grouping keys for the end-of-run tally, so they never embed a URL, byte count, status code or content type.
- **`message`** — the single per-portal log line, which does carry those specifics.

A portal missing several meta fields emits **one summary per missing field**, so "how many portals have no `og:image` at all" stays one number instead of fragmenting across every combination it appeared in.

`main()` prints the specific message per portal and closes the run with a tally grouped by rule:

```
  ⛔ noimage.test — ineligible: missing og:image
  ⛔ img404.test — ineligible: og:image returned HTTP 404 (http://…/img/missing.png)
  ⛔ imghtml.test — ineligible: og:image served as "text/html" (http://…/img/nothtml)
  ⛔ imgbig.test — ineligible: og:image exceeds the 400.0KB ceiling (truncated mid-download) (http://…/img/big.png)
  ⛔ imgdead.test — ineligible: og:image could not be fetched (http://…): connect ECONNREFUSED
  ⛔ boiler.test — ineligible: title is still BetterGov.ph's generic template copy
  ⛔ blocked.test — ineligible: robots.txt at http://… disallows BetterLGUDirectoryBot/1.0

🎉 Featured pool: 1 eligible portal(s).

Ineligible (9):
  boilerplate BetterGov.ph template copy         1
  missing og:description/meta[name=description]  1
  missing og:image                               1
  …
```

`main()`'s catch also now distinguishes a genuine `PortalUnreachableError` from a crawl bug — previously any `TypeError` inside `crawlEntry` would have been logged, and counted, as a network failure.

**The generated `_data/lgu-meta.yml` is unchanged.** This is reporting only; the eligibility rules themselves are untouched.

## Tests

Two new zero-dependency Node scripts, matching the existing `test-rotation-index.js` convention (`assert`, no runner, non-zero exit on failure):

- `scripts/test-featured-eligibility.js` — 30 assertions over the reason helpers.
- `scripts/test-crawl-reporting.js` — 11 end-to-end assertions driving the real `crawlEntry()` against two loopback HTTP servers on ephemeral ports, one per rejection path. A mis-wired branch (a network failure reported as a content-type problem) is exactly the bug that would defeat this change, and unit tests alone would not catch it.

```
node scripts/test-featured-eligibility.js   # 30 passed
node scripts/test-crawl-reporting.js        # 11 passed
node scripts/test-rotation-index.js         # 193 assertions passed (unchanged)
node scripts/test-repo-activity-data.js     # 18 assertions passed (unchanged)
```

## Notes for reviewer

- **`CHANGELOG.md` is deliberately untouched** — it states contributors should not update it in pull requests. Flagging in case a maintainer wants an entry added on their side.
- **No issue number** — this was raised from reading the code, so the branch carries no issue prefix. Happy to file one retroactively if you would rather track it.
- **`crawlEntry` and `PortalUnreachableError` are now exported** solely so the integration test can drive them. Nothing else imports them.
- **`isBoilerplate()` is still the single gate** for template-copy detection; `boilerplateReason()` early-returns on it and uses its own per-field checks only to say *which* field tripped, so a future template revision remains a one-line change in `isBoilerplate` as its comment promises.
- **Judgment call on the tally shape:** the headline count is a *portal* count while the rows are *rule* counts, so rows can sum to more than the headline when one portal fails two rules. The alternative — one row per combination — hides the systemic totals, which is the thing worth seeing.
