### PR TITLE
feat(site): render the Logo band between the hero and the directory

### DIFF
--- a/_includes/logo-band.html
+++ b/_includes/logo-band.html
@@ -1,5 +1,5 @@
 {%- comment -%}
-Logo wall (#179). A full-bleed, two-row, counter-scrolling band of resolved
+Logo band (#179). A full-bleed, two-row, counter-scrolling band of resolved
 Better LGU portal Logos, placed between the Featured hero and the directory
 table. Pure build-time Liquid, no JavaScript.
 
@@ -41,62 +41,62 @@ placeholder band (same "no fallback" rule the Featured card follows).
   {%- assign active_count = site.data.lgus | where: "status", "🟢 Active" | size -%}
   {%- assign row1 = pool | sort: "order_key" -%}
   {%- assign row2 = pool | sort: "shuffle_key" -%}
-  <section class="lw">
-    <p class="lw-caption">{{ active_count }} Better LGU portals and counting</p>
+  <section class="lb">
+    <p class="lb-caption">{{ active_count }} Better LGU portals and counting</p>
     {%- if pool.size < 8 -%}
-      <ul class="lw-rail" aria-label="Better LGU portals">
+      <ul class="lb-rail" aria-label="Better LGU portals">
         {%- for l in row1 -%}
-          <li class="lw-item">
-            <a class="lw-link" href="https://{{ l.domain }}" target="_blank" rel="noopener noreferrer">
-              <img class="lw-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="{{ l.name }}" loading="lazy">
+          <li class="lb-item">
+            <a class="lb-link" href="https://{{ l.domain }}" target="_blank" rel="noopener noreferrer">
+              <img class="lb-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="{{ l.name }}" loading="lazy">
             </a>
           </li>
         {%- endfor -%}
       </ul>
     {%- else -%}
-      <div class="lw-marquee-rows">
-        <div class="lw-marquee">
-          <ul class="lw-track lw-fwd" aria-label="Better LGU portals">
+      <div class="lb-marquee-rows">
+        <div class="lb-marquee">
+          <ul class="lb-track lb-fwd" aria-label="Better LGU portals">
             {%- for l in row1 -%}
-              <li class="lw-item">
-                <a class="lw-link" href="https://{{ l.domain }}" target="_blank" rel="noopener noreferrer">
-                  <img class="lw-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="{{ l.name }}" loading="lazy">
+              <li class="lb-item">
+                <a class="lb-link" href="https://{{ l.domain }}" target="_blank" rel="noopener noreferrer">
+                  <img class="lb-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="{{ l.name }}" loading="lazy">
                 </a>
               </li>
             {%- endfor -%}
             {%- for l in row1 -%}
-              <li class="lw-item" aria-hidden="true">
-                <a class="lw-link" href="https://{{ l.domain }}" tabindex="-1">
-                  <img class="lw-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="" loading="lazy">
+              <li class="lb-item" aria-hidden="true">
+                <a class="lb-link" href="https://{{ l.domain }}" tabindex="-1">
+                  <img class="lb-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="" loading="lazy">
                 </a>
               </li>
             {%- endfor -%}
           </ul>
         </div>
-        <div class="lw-marquee lw-second-row">
-          <ul class="lw-track lw-rev" aria-label="Better LGU portals">
+        <div class="lb-marquee lb-second-row">
+          <ul class="lb-track lb-rev" aria-label="Better LGU portals">
             {%- for l in row2 -%}
-              <li class="lw-item">
-                <a class="lw-link" href="https://{{ l.domain }}" target="_blank" rel="noopener noreferrer">
-                  <img class="lw-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="{{ l.name }}" loading="lazy">
+              <li class="lb-item">
+                <a class="lb-link" href="https://{{ l.domain }}" target="_blank" rel="noopener noreferrer">
+                  <img class="lb-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="{{ l.name }}" loading="lazy">
                 </a>
               </li>
             {%- endfor -%}
             {%- for l in row2 -%}
-              <li class="lw-item" aria-hidden="true">
-                <a class="lw-link" href="https://{{ l.domain }}" tabindex="-1">
-                  <img class="lw-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="" loading="lazy">
+              <li class="lb-item" aria-hidden="true">
+                <a class="lb-link" href="https://{{ l.domain }}" tabindex="-1">
+                  <img class="lb-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="" loading="lazy">
                 </a>
               </li>
             {%- endfor -%}
           </ul>
         </div>
       </div>
-      <ul class="lw-rail lw-static-rail" aria-label="Better LGU portals">
+      <ul class="lb-rail lb-static-rail" aria-label="Better LGU portals">
         {%- for l in row1 -%}
-          <li class="lw-item">
-            <a class="lw-link" href="https://{{ l.domain }}" target="_blank" rel="noopener noreferrer">
-              <img class="lw-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="{{ l.name }}" loading="lazy">
+          <li class="lb-item">
+            <a class="lb-link" href="https://{{ l.domain }}" target="_blank" rel="noopener noreferrer">
+              <img class="lb-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="{{ l.name }}" loading="lazy">
             </a>
           </li>
         {%- endfor -%}

--- a/_includes/logo-wall.html
+++ b/_includes/logo-wall.html
@@ -1,0 +1,106 @@
+{%- comment -%}
+Logo wall (#179). A full-bleed, two-row, counter-scrolling band of resolved
+Better LGU portal Logos, placed between the Featured hero and the directory
+table. Pure build-time Liquid, no JavaScript.
+
+Pool: `site.data.lgu-logos`, written by the Logo predicate in
+scripts/crawl-lgu-meta.js on `main` (see CONTEXT.md's "Sync pipeline" entry
+and that script's judgeLogo() for the resolution chain / sanitization).
+Ported from the validated prototype on `prototype/logo-wall` (variant B) —
+see prototype/logo-wall/FINDINGS.md for the crawl measurements behind the
+byte ceiling, size floor, and chain order.
+
+Two rows, two independent stable orders: row 1 sorts by `order_key`, row 2 by
+`shuffle_key` — a differently-salted hash of the same domain (see
+judgeLogo()'s comment in crawl-lgu-meta.js). Sorting by an unrelated hash,
+rather than reordering the same sequence, is this repo's build-time
+(Liquid — no arbitrary JS) substitute for the prototype's seeded mulberry32
+Fisher-Yates shuffle: it keeps the two rows from ever drifting back into a
+shared run of matches as they counter-scroll at equal speed.
+
+The caption count reads the number of 🟢 Active Entries in `site.data.lgus`,
+NOT the resolved Logo pool size — sourcing it from the crawl would make the
+number drop whenever a single portal shipped a broken favicon, which reads as
+LGUs leaving the movement rather than a crawl hiccup.
+
+Below ~8 resolved Logos, OR under `prefers-reduced-motion: reduce`, the
+marquee is replaced by a single bounded horizontal-scroll rail — one row,
+never a wrapping grid, so the directory table below never gets pushed further
+down as the directory grows. Below the threshold that rail is the ONLY markup
+rendered (no unused animated DOM to ship for a handful of Logos); at/above it,
+both markups render and assets/css/style.css's `prefers-reduced-motion` query
+toggles between them, since Jekyll has no server-side media-query equivalent.
+`display:none` fully removes the hidden one from the accessibility tree, so a
+screen reader is never offered the same set of links twice.
+
+If the pool is empty, this include renders nothing — no divide-by-zero, no
+placeholder band (same "no fallback" rule the Featured card follows).
+{%- endcomment -%}
+{%- assign pool = site.data.lgu-logos -%}
+{%- if pool and pool.size > 0 -%}
+  {%- assign active_count = site.data.lgus | where: "status", "🟢 Active" | size -%}
+  {%- assign row1 = pool | sort: "order_key" -%}
+  {%- assign row2 = pool | sort: "shuffle_key" -%}
+  <section class="lw">
+    <p class="lw-caption">{{ active_count }} Better LGU portals and counting</p>
+    {%- if pool.size < 8 -%}
+      <ul class="lw-rail" aria-label="Better LGU portals">
+        {%- for l in row1 -%}
+          <li class="lw-item">
+            <a class="lw-link" href="https://{{ l.domain }}" target="_blank" rel="noopener noreferrer">
+              <img class="lw-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="{{ l.name }}" loading="lazy">
+            </a>
+          </li>
+        {%- endfor -%}
+      </ul>
+    {%- else -%}
+      <div class="lw-marquee-rows">
+        <div class="lw-marquee">
+          <ul class="lw-track lw-fwd" aria-label="Better LGU portals">
+            {%- for l in row1 -%}
+              <li class="lw-item">
+                <a class="lw-link" href="https://{{ l.domain }}" target="_blank" rel="noopener noreferrer">
+                  <img class="lw-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="{{ l.name }}" loading="lazy">
+                </a>
+              </li>
+            {%- endfor -%}
+            {%- for l in row1 -%}
+              <li class="lw-item" aria-hidden="true">
+                <a class="lw-link" href="https://{{ l.domain }}" tabindex="-1">
+                  <img class="lw-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="" loading="lazy">
+                </a>
+              </li>
+            {%- endfor -%}
+          </ul>
+        </div>
+        <div class="lw-marquee lw-second-row">
+          <ul class="lw-track lw-rev" aria-label="Better LGU portals">
+            {%- for l in row2 -%}
+              <li class="lw-item">
+                <a class="lw-link" href="https://{{ l.domain }}" target="_blank" rel="noopener noreferrer">
+                  <img class="lw-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="{{ l.name }}" loading="lazy">
+                </a>
+              </li>
+            {%- endfor -%}
+            {%- for l in row2 -%}
+              <li class="lw-item" aria-hidden="true">
+                <a class="lw-link" href="https://{{ l.domain }}" tabindex="-1">
+                  <img class="lw-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="" loading="lazy">
+                </a>
+              </li>
+            {%- endfor -%}
+          </ul>
+        </div>
+      </div>
+      <ul class="lw-rail lw-static-rail" aria-label="Better LGU portals">
+        {%- for l in row1 -%}
+          <li class="lw-item">
+            <a class="lw-link" href="https://{{ l.domain }}" target="_blank" rel="noopener noreferrer">
+              <img class="lw-img" src="{{ site.baseurl }}assets/images/lgu-logos/{{ l.file }}" alt="{{ l.name }}" loading="lazy">
+            </a>
+          </li>
+        {%- endfor -%}
+      </ul>
+    {%- endif -%}
+  </section>
+{%- endif -%}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -441,15 +441,15 @@ main tr:last-child td {
   main td, main th { padding: 0.75rem 1rem; }
 }
 
-/* ---- Logo wall (#179) ----
+/* ---- Logo band (#179) ----
    Full-bleed: breaks out of .prose/main's max-w-7xl + px-4 container via the
    standard 100vw/-50vw technique, so the band spans the full viewport width
    regardless of where it sits in the document. No plate — Logos sit directly
    on the section background (--color-gray-100), unlike the Featured card's
    glass panel. Ported from prototype/logo-wall (variant B); see that
-   branch's FINDINGS.md and _includes/logo-wall.html for the data/markup this
+   branch's FINDINGS.md and _includes/logo-band.html for the data/markup this
    styles. */
-.lw {
+.lb {
   position: relative;
   left: 50%;
   right: 50%;
@@ -463,7 +463,7 @@ main tr:last-child td {
   margin-bottom: 2rem;
 }
 
-.lw-caption {
+.lb-caption {
   margin: 0 0 1rem;
   text-align: center;
   font-size: 0.8125rem;
@@ -473,7 +473,7 @@ main tr:last-child td {
   color: var(--color-gray-600);
 }
 
-.lw-item {
+.lb-item {
   list-style: none;
   flex: 0 0 auto;
 }
@@ -481,7 +481,7 @@ main tr:last-child td {
 /* No plate: an explicit box (not max-*) so a large intrinsic Logo can't
    overflow and get visually clipped — the page's Tailwind preflight sets
    img height:auto, which would otherwise let that happen. */
-.lw-link {
+.lb-link {
   display: block;
   box-sizing: border-box;
   width: 120px;
@@ -489,7 +489,7 @@ main tr:last-child td {
   transition: transform 0.2s ease;
 }
 
-.lw-img {
+.lb-img {
   display: block;
   width: 100%;
   height: 100%;
@@ -502,70 +502,70 @@ main tr:last-child td {
    touch devices always see full color (they have no hover state to promise
    a reveal on). */
 @media (hover: hover) and (pointer: fine) {
-  .lw-img {
+  .lb-img {
     filter: grayscale(1);
     opacity: 0.75;
   }
-  .lw-link:hover .lw-img,
-  .lw-link:focus-visible .lw-img {
+  .lb-link:hover .lb-img,
+  .lb-link:focus-visible .lb-img {
     filter: grayscale(0);
     opacity: 1;
   }
-  .lw-link:hover {
+  .lb-link:hover {
     transform: translateY(-2px);
   }
 }
 
-.lw-link:focus-visible {
+.lb-link:focus-visible {
   outline: 2px solid var(--color-primary-600);
   outline-offset: 3px;
   border-radius: 4px;
 }
 
 /* Marquee mechanics: each row's track is duplicated (row1+row1, row2+row2 —
-   see logo-wall.html) so translating exactly -50% loops seamlessly. */
-.lw-marquee {
+   see logo-band.html) so translating exactly -50% loops seamlessly. */
+.lb-marquee {
   overflow: hidden;
   -webkit-mask-image: linear-gradient(90deg, transparent, #000 6%, #000 94%, transparent);
   mask-image: linear-gradient(90deg, transparent, #000 6%, #000 94%, transparent);
 }
 
-.lw-track {
+.lb-track {
   display: flex;
   gap: 1.25rem;
   align-items: center;
   margin: 0;
   padding: 0.5rem 0;
   width: max-content;
-  animation: lw-scroll 60s linear infinite;
+  animation: lb-scroll 60s linear infinite;
 }
 
-.lw-rev {
+.lb-rev {
   animation-direction: reverse;
 }
 
-.lw-second-row {
+.lb-second-row {
   margin-top: 0.75rem;
 }
 
-@keyframes lw-scroll {
+@keyframes lb-scroll {
   from { transform: translateX(0); }
   to { transform: translateX(-50%); }
 }
 
 /* Pause on hover AND focus-within (#179) — focus-within covers keyboard
    users tabbing into a Logo link inside a still-animating row. */
-.lw-marquee:hover .lw-track,
-.lw-marquee:focus-within .lw-track {
+.lb-marquee:hover .lb-track,
+.lb-marquee:focus-within .lb-track {
   animation-play-state: paused;
 }
 
 /* Bounded static rail — always exactly one row tall, scrolls rather than
    wraps, so the directory table below it never gets pushed down further as
    the directory grows. This is the ONLY markup rendered below ~8 resolved
-   Logos (see logo-wall.html), and doubles as the prefers-reduced-motion
-   fallback for larger pools via .lw-static-rail below. */
-.lw-rail {
+   Logos (see logo-band.html), and doubles as the prefers-reduced-motion
+   fallback for larger pools via .lb-static-rail below. */
+.lb-rail {
   display: flex;
   gap: 1.25rem;
   align-items: center;
@@ -578,22 +578,22 @@ main tr:last-child td {
   scrollbar-width: thin;
 }
 
-.lw-rail .lw-item {
+.lb-rail .lb-item {
   scroll-snap-align: start;
 }
 
 /* At/above the ~8 threshold, both the marquee and the static rail render;
    only one is ever exposed to the accessibility tree at a time, since
    display:none removes an element from it entirely. */
-.lw-static-rail {
+.lb-static-rail {
   display: none;
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .lw-marquee-rows {
+  .lb-marquee-rows {
     display: none;
   }
-  .lw-static-rail {
+  .lb-static-rail {
     display: flex;
   }
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -440,3 +440,160 @@ main tr:last-child td {
   .prose h2 { font-size: 1.5rem; }
   main td, main th { padding: 0.75rem 1rem; }
 }
+
+/* ---- Logo wall (#179) ----
+   Full-bleed: breaks out of .prose/main's max-w-7xl + px-4 container via the
+   standard 100vw/-50vw technique, so the band spans the full viewport width
+   regardless of where it sits in the document. No plate — Logos sit directly
+   on the section background (--color-gray-100), unlike the Featured card's
+   glass panel. Ported from prototype/logo-wall (variant B); see that
+   branch's FINDINGS.md and _includes/logo-wall.html for the data/markup this
+   styles. */
+.lw {
+  position: relative;
+  left: 50%;
+  right: 50%;
+  width: 100vw;
+  margin-left: -50vw;
+  margin-right: -50vw;
+  background: var(--color-gray-100);
+  border-block: 1px solid var(--color-gray-200);
+  padding: 1.75rem 0;
+  margin-top: 0;
+  margin-bottom: 2rem;
+}
+
+.lw-caption {
+  margin: 0 0 1rem;
+  text-align: center;
+  font-size: 0.8125rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--color-gray-600);
+}
+
+.lw-item {
+  list-style: none;
+  flex: 0 0 auto;
+}
+
+/* No plate: an explicit box (not max-*) so a large intrinsic Logo can't
+   overflow and get visually clipped — the page's Tailwind preflight sets
+   img height:auto, which would otherwise let that happen. */
+.lw-link {
+  display: block;
+  box-sizing: border-box;
+  width: 120px;
+  height: 72px;
+  transition: transform 0.2s ease;
+}
+
+.lw-img {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  object-position: center;
+  transition: filter 0.2s ease, opacity 0.2s ease;
+}
+
+/* Grayscale-until-hover only where hover is a real pointer affordance —
+   touch devices always see full color (they have no hover state to promise
+   a reveal on). */
+@media (hover: hover) and (pointer: fine) {
+  .lw-img {
+    filter: grayscale(1);
+    opacity: 0.75;
+  }
+  .lw-link:hover .lw-img,
+  .lw-link:focus-visible .lw-img {
+    filter: grayscale(0);
+    opacity: 1;
+  }
+  .lw-link:hover {
+    transform: translateY(-2px);
+  }
+}
+
+.lw-link:focus-visible {
+  outline: 2px solid var(--color-primary-600);
+  outline-offset: 3px;
+  border-radius: 4px;
+}
+
+/* Marquee mechanics: each row's track is duplicated (row1+row1, row2+row2 —
+   see logo-wall.html) so translating exactly -50% loops seamlessly. */
+.lw-marquee {
+  overflow: hidden;
+  -webkit-mask-image: linear-gradient(90deg, transparent, #000 6%, #000 94%, transparent);
+  mask-image: linear-gradient(90deg, transparent, #000 6%, #000 94%, transparent);
+}
+
+.lw-track {
+  display: flex;
+  gap: 1.25rem;
+  align-items: center;
+  margin: 0;
+  padding: 0.5rem 0;
+  width: max-content;
+  animation: lw-scroll 60s linear infinite;
+}
+
+.lw-rev {
+  animation-direction: reverse;
+}
+
+.lw-second-row {
+  margin-top: 0.75rem;
+}
+
+@keyframes lw-scroll {
+  from { transform: translateX(0); }
+  to { transform: translateX(-50%); }
+}
+
+/* Pause on hover AND focus-within (#179) — focus-within covers keyboard
+   users tabbing into a Logo link inside a still-animating row. */
+.lw-marquee:hover .lw-track,
+.lw-marquee:focus-within .lw-track {
+  animation-play-state: paused;
+}
+
+/* Bounded static rail — always exactly one row tall, scrolls rather than
+   wraps, so the directory table below it never gets pushed down further as
+   the directory grows. This is the ONLY markup rendered below ~8 resolved
+   Logos (see logo-wall.html), and doubles as the prefers-reduced-motion
+   fallback for larger pools via .lw-static-rail below. */
+.lw-rail {
+  display: flex;
+  gap: 1.25rem;
+  align-items: center;
+  margin: 0;
+  padding: 0.5rem 1.25rem;
+  list-style: none;
+  overflow-x: auto;
+  scroll-snap-type: x proximity;
+  overscroll-behavior-x: contain;
+  scrollbar-width: thin;
+}
+
+.lw-rail .lw-item {
+  scroll-snap-align: start;
+}
+
+/* At/above the ~8 threshold, both the marquee and the static rail render;
+   only one is ever exposed to the accessibility tree at a time, since
+   display:none removes an element from it entirely. */
+.lw-static-rail {
+  display: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .lw-marquee-rows {
+    display: none;
+  }
+  .lw-static-rail {
+    display: flex;
+  }
+}

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ title: Home
 
 A community-maintained directory of **Better LGU** digital transparency portals across the Philippines — find an existing portal before you build, contribute to one, or start your own. Each entry links to the LGU's portal, source repository, and social pages, along with its current maintenance status.
 
-{%- include logo-wall.html -%}
+{%- include logo-band.html -%}
 
 ## 📋 Directory
 

--- a/index.md
+++ b/index.md
@@ -6,6 +6,8 @@ title: Home
 
 A community-maintained directory of **Better LGU** digital transparency portals across the Philippines — find an existing portal before you build, contribute to one, or start your own. Each entry links to the LGU's portal, source repository, and social pages, along with its current maintenance status.
 
+{%- include logo-wall.html -%}
+
 ## 📋 Directory
 
 <!-- Interactive Search and Filters -->


### PR DESCRIPTION
## Summary

Part 2 of 2 for #179 (Logo Band). Companion to jmacj/better-lgu-directory#182 (the `main`-side crawl split + Logo resolution/storage) — this PR covers the `main-pages`-only site rendering (index.md, CSS; this repo splits site changes into `main-pages` PRs and data/workflow changes into `main` PRs, matching #67/#68, #106, and #132/#134/#135's precedent).

Ported from the validated prototype on `prototype/logo-wall` (variant B — already checked against the real live site and all 26 Active portals); see that branch's `FINDINGS.md` for the crawl measurements backing the byte ceiling / size floor / chain order decisions, carried over unchanged from the companion `main` PR.

- New `_includes/logo-band.html`: pure build-time Liquid, no JavaScript. Pool = `site.data.lgu-logos` (written by #182's crawl — this include renders nothing until that PR merges and a crawl runs, same "empty pool → no render" rule the Featured card follows). Two counter-scrolling rows, no plate — Logos sit directly on the section background. Row 1 sorts by `order_key`, row 2 by `shuffle_key` (a differently-salted hash of the same domain, set by #182) — see that PR's notes for why this substitutes for a literal seeded Fisher-Yates shuffle under Jekyll's Liquid. Each Logo is a link with the LGU name as its accessible name (via the `<img alt>`), rows are `<ul>`s.
- Below ~8 resolved Logos, only a single bounded `<ul class="lb-rail">` renders — no marquee markup at all. At/above the threshold, both the marquee and a `.lb-static-rail` render; `assets/css/style.css`'s `prefers-reduced-motion: reduce` query toggles between them (swaps to the same bounded rail, never a wrapping grid — the directory table must never get pushed down as the directory grows). `display:none` fully removes the hidden one from the accessibility tree, so nothing is ever exposed twice to a screen reader.
- Caption reads the count of 🟢 Active `site.data.lgus` entries, not the resolved Logo pool size (a broken favicon on one portal must not read as LGUs leaving the movement).
- `assets/css/style.css`: `.lb-*` rules — full-bleed via the standard `100vw`/`-50vw` breakout (spans the viewport regardless of `.prose`'s `max-w-7xl`+`px-4`), grayscale-until-hover gated behind `(hover: hover) and (pointer: fine)`, pause-on-hover and pause-on-`focus-within` on each row's track.

## Acceptance criteria (this PR's share)

- [x] Two rows scrolling in opposite directions, no plate
- [x] Second row uses an independent stable order (`shuffle_key`), not a rotation of row 1
- [x] Each Logo is a link with the LGU name as accessible name; rows are `<ul>`s
- [x] Pause on hover and focus-within
- [x] `prefers-reduced-motion: reduce` swaps to a single bounded rail, not a wrapping grid
- [x] Below ~8 resolved Logos, the marquee is skipped and the static rail renders
- [x] Heading/caption count sources Active entries, not the resolved-Logo count
- [x] Grayscale-until-hover gated behind `(hover: hover) and (pointer: fine)`
- [ ] Crawl / resolution / storage AC items — covered by the companion `main` PR (#182), not this one

## Notes for reviewer

- **Could not run a live `bundle exec jekyll build`** in this environment (no `ruby`/`bundler` installed) — same gap PR135 flagged for the Featured card. Hand-traced the Liquid (tag balance checked programmatically) rather than compiled and visually verified. Please build locally or check the deployed preview after merge, particularly the two `sort:` filters and the `pool.size < 8` branch.
- **Judgment call — heading count vs. prototype's variant B.** `prototype/logo-wall/FINDINGS.md` describes variant B as "no heading at all," but this issue's AC explicitly calls for "the band's heading count" sourced from Active entries — the two conflict. I added a small, unobtrusive caption line (`.lb-caption`, uppercase micro-text) above the band rather than importing variant A's full count-led treatment, to satisfy the literal AC while keeping variant B's ornamental, heading-light spirit. Flagging in case the intent was either "no caption at all" or a more prominent count.
- **`shuffle_key` vs. a literal seeded shuffle.** The issue's AC describes the prototype's mulberry32 Fisher-Yates shuffle. Jekyll's Liquid has no arbitrary JS at build time, so row 2 instead sorts by a second, differently-salted hash per Entry (set in #182). This satisfies the AC's actual requirement (rows never drift into a shared run of matches) without literally porting the shuffle algorithm — flagging as a deliberate substitution, not an oversight.
- **Full-bleed breakout** uses the standard `100vw`/`-50vw` CSS technique to escape `.prose`'s `max-w-7xl`+`px-4` container. This can introduce a horizontal scrollbar in rare cases if a scrollbar's own width isn't accounted for by the browser; existing `overflow-x-clip` on the nav suggests the same caveat already applies elsewhere on this page, so I did not add extra guarding for it.
- **Out of scope (per the issue):** Variant A (count-led band, the shelved alternative) and the portal-requirements Discussion post are both explicitly not part of this PR.
- **No `_data/lgu-logos.yml` exists on `main-pages` yet** — it's generated, so I didn't hand-author one (same convention `_data/lgu-meta.yml` follows). Until #182 merges and a crawl runs, this section renders nothing, which is correct behavior for an empty/missing pool.

Closes part of #179 (see jmacj/better-lgu-directory#182 for the rest).


## Follow-up fix (post-merge review, Jan 2026-08-16)

Jan flagged: on the rendered home page, the logo band's HTML tags (`<section class="lb">`, `<ul class="lb-track lb-fwd">`, etc.) showed up as literal escaped text right after the intro paragraph, with only the `<img>` logos rendering as real images.

**Root cause:** `index.md` included the band with `{%- include logo-band.html -%}` — the `-` whitespace-control modifiers strip the blank lines immediately surrounding the tag in the source. That collapsed the blank-line separation kramdown needs to recognize a raw HTML block, so it folded the rendered `<section>` markup into the surrounding paragraph/heading as inline text and HTML-escaped it.

**Fix:** dropped the `-` trim modifiers — `{% include logo-band.html %}` — which preserves the blank lines before/after the tag in the compiled output.

Could not verify with a real `bundle exec jekyll build` (still no `ruby`/`bundler` in this sandbox, same gap as before) — verified structurally instead: the blank lines around the include tag are now intact, matching every other working raw-HTML block on this page (e.g. the `<div markdown="1">` wrappers). Please confirm on the deployed preview.
