### PR TITLE
fix(site): logo band not rendering — kramdown escaping + .prose specificity

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -104,6 +104,10 @@
     </section>
     {% endif %}
 
+    {% if page.title == 'Home' %}
+    {%- include logo-band.html -%}
+    {% endif %}
+
     <main class="max-w-7xl mx-auto px-4 py-8 md:py-16">
         <div class="prose max-w-none prose-lg md:prose-xl">
             <div id="directory">

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -463,7 +463,15 @@ main tr:last-child td {
   margin-bottom: 2rem;
 }
 
-.lb-caption {
+/* `.lb` sits inside `.prose` (index.md's content column), whose bare-element
+   rules (`.prose p`, `.prose ul`, `.prose li` — see above) carry higher
+   specificity (0,1,1) than a single class like `.lb-caption`/`.lb-track`/
+   `.lb-item` (0,1,0) and would otherwise win margin/padding/list-style on
+   these elements regardless of source order, breaking the flush alignment
+   the prototype had (it rendered outside any `.prose` ancestor). Selectors
+   below that override a `.prose <element>` rule are scoped under `.lb ` to
+   clear that bar. */
+.lb .lb-caption {
   margin: 0 0 1rem;
   text-align: center;
   font-size: 0.8125rem;
@@ -473,7 +481,9 @@ main tr:last-child td {
   color: var(--color-gray-600);
 }
 
-.lb-item {
+.lb .lb-item {
+  margin: 0;
+  padding: 0;
   list-style: none;
   flex: 0 0 auto;
 }
@@ -530,12 +540,13 @@ main tr:last-child td {
   mask-image: linear-gradient(90deg, transparent, #000 6%, #000 94%, transparent);
 }
 
-.lb-track {
+.lb .lb-track {
   display: flex;
   gap: 1.25rem;
   align-items: center;
   margin: 0;
   padding: 0.5rem 0;
+  list-style: none;
   width: max-content;
   animation: lb-scroll 60s linear infinite;
 }

--- a/index.md
+++ b/index.md
@@ -6,8 +6,6 @@ title: Home
 
 A community-maintained directory of **Better LGU** digital transparency portals across the Philippines — find an existing portal before you build, contribute to one, or start your own. Each entry links to the LGU's portal, source repository, and social pages, along with its current maintenance status.
 
-{% include logo-band.html %}
-
 ## 📋 Directory
 
 <!-- Interactive Search and Filters -->

--- a/index.md
+++ b/index.md
@@ -6,7 +6,7 @@ title: Home
 
 A community-maintained directory of **Better LGU** digital transparency portals across the Philippines — find an existing portal before you build, contribute to one, or start your own. Each entry links to the LGU's portal, source repository, and social pages, along with its current maintenance status.
 
-{%- include logo-band.html -%}
+{% include logo-band.html %}
 
 ## 📋 Directory
 


### PR DESCRIPTION
## What broke

Three issues found live on the merged #179 logo band:

1. **Wrong placement**: the prototype injects the band directly before `<main>` — a sibling of the hero section, ahead of the intro paragraph, search bar, and directory table entirely. This shipped inside `index.md`'s content instead, which renders inside `<main>`/`.prose`, so it landed *after* the intro paragraph (Jan caught this).
2. **kramdown escaping**: with the include living in `index.md`, `{%- include logo-band.html -%}`'s whitespace-trim dashes collapsed the blank lines kramdown needs around a raw HTML block, so it rendered as literal escaped text — only the bare `<img>` tags parsed (screenshot from Jan).
3. **`.prose` specificity**: `.lb-caption`/`.lb-item`/`.lb-track` were unscoped, losing to `.prose`'s bare-element rules on margin/padding/list-style, which would have broken the flush layout even once escaping was fixed.

## Fix

- **Root fix**: move the include from `index.md` into `_layouts/default.html`, right before `<main>`, gated to `page.title == 'Home'` (same pattern as `featured-portal.html`'s hero include). This matches the prototype's actual placement. It also removes kramdown from the picture entirely — layout files are pure Liquid, never passed through the markdown converter, so issue 2 can't recur here regardless of whitespace-control dashes.
- Scoped `.lb-caption`/`.lb-item`/`.lb-track` under `.lb ` to clear the `.prose` specificity bar (harmless now that the band lives outside `.prose`, but keeps the pattern consistent with `.lb-rail` and defends against the include ever moving back).

## Why a new PR

#183 (original #179 site PR) was already merged before these bugs were caught live; this targets `main-pages` directly as a follow-up fix.

## Verification

No ruby/bundler available in this sandbox (same known gap as prior PRs on this repo) — could not run a real Jekyll build. Placement fix is a straight structural move verified by reading the prototype's own injection logic (`build-prototype.js`: `html.indexOf('<main>')`); recommend a quick visual check on the next deploy.