### PR TITLE
fix(data): flag duplicate Logo bytes, keep them apart in the render

### DIFF
--- a/scripts/crawl-lgu-meta.js
+++ b/scripts/crawl-lgu-meta.js
@@ -727,7 +727,10 @@ async function judgeLogo(entry, displayDomain, fetched) {
                     // (see FINDINGS.md on prototype/logo-wall) — sorting by an
                     // unrelated hash is this repo's build-time (Liquid, no
                     // arbitrary JS) substitute for the prototype's mulberry32
-                    // Fisher-Yates shuffle.
+                    // Fisher-Yates shuffle. These are only the SEED values —
+                    // main() replaces both with rank keys once the whole pool
+                    // is known, so byte-identical Logos can be kept apart
+                    // (see assignRankKeys()).
                     order_key: sha1First8(displayDomain),
                     shuffle_key: sha1First8(`${displayDomain}:lb2`),
                 },
@@ -798,6 +801,70 @@ function formatLguLogosYaml(rows) {
             ].join('\n'),
         )
         .join('\n');
+}
+
+// Hashes the bytes actually on disk for every resolved row (fresh or
+// kept-last-known-good), keyed by domain — the single read pass that both
+// findDuplicateLogos() and assignRankKeys()'s anti-adjacency swap need.
+function computeContentHashes(rows, logoDir = LOGO_DIR) {
+    const byDomain = new Map();
+    for (const row of rows) {
+        const filePath = path.join(logoDir, row.file);
+        if (!fs.existsSync(filePath)) continue;
+        byDomain.set(row.domain, crypto.createHash('sha256').update(fs.readFileSync(filePath)).digest('hex'));
+    }
+    return byDomain;
+}
+
+// Two portals can legitimately end up serving the same image bytes (a shared
+// starter template's default icon, left unedited) — the crawl has no way to
+// tell which one is the "real" owner, so this doesn't drop or pick a winner.
+// It only flags the collision in the run summary, same as a Featured
+// rejection, for a human to sort out (surfaced in the portal-requirements
+// Discussion post).
+function findDuplicateLogos(hashByDomain) {
+    const byHash = new Map();
+    for (const [domain, hash] of hashByDomain) {
+        if (!byHash.has(hash)) byHash.set(hash, []);
+        byHash.get(hash).push(domain);
+    }
+    return [...byHash.values()].filter((domains) => domains.length > 1);
+}
+
+// If two byte-identical Logos would land next to each other after sorting by
+// the base key, swap the second one forward to the next row that isn't a
+// duplicate of it. Resolves the realistic case (a small handful of duplicate
+// pairs) without a full optimal rearrangement — if every row in the set
+// shares one hash, adjacency can't be avoided and the run is left as-is.
+function separateAdjacentDuplicates(rows, hashByDomain) {
+    const arr = rows.slice();
+    const hashOf = (row) => hashByDomain.get(row.domain);
+    for (let i = 0; i < arr.length - 1; i++) {
+        const h = hashOf(arr[i]);
+        if (h === undefined || h !== hashOf(arr[i + 1])) continue;
+        let j = i + 2;
+        while (j < arr.length && hashOf(arr[j]) === h) j++;
+        if (j < arr.length) {
+            [arr[i + 1], arr[j]] = [arr[j], arr[i + 1]];
+        }
+    }
+    return arr;
+}
+
+// Liquid renders the marquee rows by sorting on `order_key`/`shuffle_key`, so
+// the only way for the anti-adjacency swap above to survive into the render
+// is to bake the swapped order into the sort key itself: sort by the row's
+// current key, separate duplicates, then replace the key with a zero-padded
+// rank reflecting that final sequence. Mutates `targetField` on the row
+// objects in place.
+function assignRankKeys(rows, baseKeyField, hashByDomain, targetField) {
+    const sorted = rows
+        .slice()
+        .sort((a, b) => (a[baseKeyField] < b[baseKeyField] ? -1 : a[baseKeyField] > b[baseKeyField] ? 1 : 0));
+    const separated = separateAdjacentDuplicates(sorted, hashByDomain);
+    separated.forEach((row, i) => {
+        row[targetField] = String(i).padStart(4, '0');
+    });
 }
 
 async function main() {
@@ -905,6 +972,16 @@ async function main() {
         console.log(`\n${featuredSummary}`);
     }
 
+    // Re-key row order AFTER the full pool is known: order_key/shuffle_key
+    // start as domain hashes (assigned per-row in judgeLogo(), before any
+    // row knows about its neighbours), then get replaced here with
+    // rank-based keys that keep byte-identical Logos from landing adjacent
+    // in either rendered row. Both content-hash uses (this + the duplicate
+    // report below) share one file-read pass.
+    const contentHashByDomain = computeContentHashes(logoRows);
+    assignRankKeys(logoRows, 'order_key', contentHashByDomain, 'order_key');
+    assignRankKeys(logoRows, 'shuffle_key', contentHashByDomain, 'shuffle_key');
+
     const logoDataDir = path.dirname(LOGO_META_PATH);
     if (!fs.existsSync(logoDataDir)) {
         fs.mkdirSync(logoDataDir, { recursive: true });
@@ -914,6 +991,16 @@ async function main() {
     const logoSummary = formatIneligibleSummary(logoRejections, 'Logo ineligible');
     if (logoSummary) {
         console.log(`\n${logoSummary}`);
+    }
+
+    const duplicateLogoGroups = findDuplicateLogos(contentHashByDomain);
+    if (duplicateLogoGroups.length > 0) {
+        console.log(
+            `\n⚠️  Duplicate Logo bytes (${duplicateLogoGroups.length} group(s)) — same image resolved for multiple portals, not auto-resolved (kept apart in the render, flagged here for a human to sort out):`,
+        );
+        for (const domains of duplicateLogoGroups) {
+            console.log(`   - ${domains.join(', ')}`);
+        }
     }
 }
 
@@ -957,4 +1044,8 @@ module.exports = {
     judgeLogo,
     parseExistingLguLogos,
     formatLguLogosYaml,
+    computeContentHashes,
+    findDuplicateLogos,
+    separateAdjacentDuplicates,
+    assignRankKeys,
 };

--- a/scripts/test-logo-eligibility.js
+++ b/scripts/test-logo-eligibility.js
@@ -8,13 +8,18 @@
 //
 // Covers: the candidate chain order (SVG rel=icon > other rel=icon > largest
 // manifest icon > apple-touch-icon > favicon.ico), the 64px floor (SVG
-// exempt), the 1.2MB byte ceiling, and SVG sanitization
-// (script/foreignObject/external href rejected). Isolated function tests
-// against fixed inputs — no live HTTP — matching test-featured-eligibility.js;
-// the wired end-to-end behaviour (fetch -> candidate -> row) is left to a
-// live/manual run, same split as the Featured predicate's two test files.
+// exempt), the 1.2MB byte ceiling, SVG sanitization
+// (script/foreignObject/external href rejected), and the duplicate-Logo
+// detection + anti-adjacency rank keys (#179 follow-up). Isolated function
+// tests against fixed inputs — no live HTTP — matching
+// test-featured-eligibility.js; the wired end-to-end behaviour (fetch ->
+// candidate -> row) is left to a live/manual run, same split as the Featured
+// predicate's two test files.
 
 const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const {
     LOGO_MIN_PX,
     LOGO_MAX_BYTES,
@@ -23,6 +28,10 @@ const {
     logoCandidates,
     intrinsicPx,
     svgIsUnsafe,
+    computeContentHashes,
+    findDuplicateLogos,
+    separateAdjacentDuplicates,
+    assignRankKeys,
 } = require('./crawl-lgu-meta.js');
 
 let failures = 0;
@@ -193,6 +202,119 @@ console.log('\nlogoCandidates() — chain order');
             false,
         );
     });
+
+    console.log('\ncomputeContentHashes() / findDuplicateLogos()');
+
+    const fixtureDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lgu-logo-hash-'));
+    const write = (file, content) => fs.writeFileSync(path.join(fixtureDir, file), content);
+    write('a.svg', '<svg>same</svg>');
+    write('b.svg', '<svg>same</svg>');
+    write('c.svg', '<svg>different</svg>');
+
+    test('identical bytes hash the same, different bytes hash differently', () => {
+        const hashes = computeContentHashes(
+            [
+                { domain: 'a.example', file: 'a.svg' },
+                { domain: 'b.example', file: 'b.svg' },
+                { domain: 'c.example', file: 'c.svg' },
+            ],
+            fixtureDir,
+        );
+        assert.strictEqual(hashes.get('a.example'), hashes.get('b.example'));
+        assert.notStrictEqual(hashes.get('a.example'), hashes.get('c.example'));
+    });
+
+    test('groups byte-identical rows and leaves unique ones out', () => {
+        const hashes = computeContentHashes(
+            [
+                { domain: 'a.example', file: 'a.svg' },
+                { domain: 'b.example', file: 'b.svg' },
+                { domain: 'c.example', file: 'c.svg' },
+            ],
+            fixtureDir,
+        );
+        const groups = findDuplicateLogos(hashes);
+        assert.strictEqual(groups.length, 1);
+        assert.deepStrictEqual(groups[0].sort(), ['a.example', 'b.example']);
+    });
+
+    test('reports nothing when every hash is unique', () => {
+        const hashes = computeContentHashes(
+            [
+                { domain: 'a.example', file: 'a.svg' },
+                { domain: 'c.example', file: 'c.svg' },
+            ],
+            fixtureDir,
+        );
+        assert.deepStrictEqual(findDuplicateLogos(hashes), []);
+    });
+
+    console.log('\nseparateAdjacentDuplicates() / assignRankKeys()');
+
+    test('swaps an adjacent duplicate forward to break up the run', () => {
+        const hashes = new Map([
+            ['a', 'dup'],
+            ['b', 'dup'],
+            ['c', 'unique'],
+        ]);
+        const separated = separateAdjacentDuplicates(
+            [{ domain: 'a' }, { domain: 'b' }, { domain: 'c' }],
+            hashes,
+        );
+        const domains = separated.map((r) => r.domain);
+        assert.notStrictEqual(domains[0], undefined);
+        for (let i = 0; i < domains.length - 1; i++) {
+            assert.notStrictEqual(hashes.get(domains[i]), hashes.get(domains[i + 1]));
+        }
+    });
+
+    test('leaves a run alone when there is nothing non-duplicate to swap in', () => {
+        const hashes = new Map([
+            ['a', 'dup'],
+            ['b', 'dup'],
+        ]);
+        const separated = separateAdjacentDuplicates([{ domain: 'a' }, { domain: 'b' }], hashes);
+        assert.deepStrictEqual(separated.map((r) => r.domain), ['a', 'b']);
+    });
+
+    test('assignRankKeys keeps byte-identical rows apart in the resulting order', () => {
+        const hashes = new Map([
+            ['a', 'dup'],
+            ['b', 'dup'],
+            ['c', 'unique1'],
+            ['d', 'unique2'],
+        ]);
+        // Seed order_key so the two duplicates would otherwise sort adjacent.
+        const rows = [
+            { domain: 'a', order_key: '0001' },
+            { domain: 'b', order_key: '0002' },
+            { domain: 'c', order_key: '0003' },
+            { domain: 'd', order_key: '0004' },
+        ];
+        assignRankKeys(rows, 'order_key', hashes, 'order_key');
+        const byRank = rows.slice().sort((x, y) => (x.order_key < y.order_key ? -1 : 1));
+        const domains = byRank.map((r) => r.domain);
+        for (let i = 0; i < domains.length - 1; i++) {
+            assert.notStrictEqual(hashes.get(domains[i]), hashes.get(domains[i + 1]));
+        }
+    });
+
+    test('assignRankKeys produces zero-padded rank strings, not raw hashes', () => {
+        const hashes = new Map([
+            ['a', 'x'],
+            ['b', 'y'],
+        ]);
+        const rows = [
+            { domain: 'a', order_key: '0001' },
+            { domain: 'b', order_key: '0002' },
+        ];
+        assignRankKeys(rows, 'order_key', hashes, 'order_key');
+        for (const row of rows) {
+            assert.match(row.order_key, /^\d{4}$/);
+        }
+    });
+
+    fs.rmSync(fixtureDir, { recursive: true, force: true });
 
     console.log(failures === 0 ? '\n✅ All Logo eligibility tests passed.\n' : `\n❌ ${failures} test(s) failed.\n`);
     process.exit(failures === 0 ? 0 : 1);


### PR DESCRIPTION
## What broke

BetterCainta and BetterSolano currently resolve byte-identical Logo SVGs (same Illustrator export, only the `id="better-*"` string differs — verified with a manual diff, not a crawl bug: Cainta's site actually serves Solano's icon, likely an unedited shared starter template). Two problems fall out of this:

1. There's no signal anywhere that this happened — it's silent.
2. Because `order_key`/`shuffle_key` are per-row domain hashes, two byte-identical Logos can land right next to each other in a rendered row purely by chance.

## Fix

- `computeContentHashes()` — one sha256-per-file pass over the resolved pool.
- `findDuplicateLogos()` — groups by hash, returns any group with >1 domain. **Does not drop or pick a winner** — the crawl has no way to know which portal is the "real" owner of a shared image, so it only flags the collision in the run summary (same treatment as a Featured rejection), for a human to sort out later (surfaces in the planned portal-requirements Discussion post).
- `separateAdjacentDuplicates()` + `assignRankKeys()` — after the whole pool is known, re-sorts each row's seed key (the domain hash from `judgeLogo()`), greedily swaps any adjacent byte-identical pair forward to the next non-duplicate, then bakes that separated order into a zero-padded rank key. Liquid renders by `sort: order_key` / `sort: shuffle_key`, so replacing the key is the only way the swap survives into the actual page — reordering an in-memory array wouldn't do anything on its own.

## Not attempted

Picking which of a duplicate pair is the "original" — there's no timestamp or ownership signal in SVG bytes to base that on. Flag-and-defer to a human is the only defensible move here.

## Verification

`node scripts/test-logo-eligibility.js` — new coverage for hashing, grouping, the adjacency swap, and rank-key assignment, all passing. `test-featured-eligibility.js` and `test-crawl-reporting.js` unaffected, still pass unchanged. No live crawl run (no net egress in this sandbox, same known gap as prior PRs).