### PR TITLE
fix(site): logo band scrolls both rows same direction + causes horizontal scroll

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -31,6 +31,12 @@ body {
   margin: 0;
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
+  /* .lb's 100vw/-50vw full-bleed breakout (#179) overshoots the real
+     viewport whenever a vertical scrollbar is present, since 100vw includes
+     the scrollbar's own width — same reason the nav already clips itself
+     with overflow-x-clip. Clipped at body so the sliver never shows as a
+     page-level horizontal scrollbar. */
+  overflow-x: clip;
 }
 
 .hero-gradient {
@@ -551,7 +557,7 @@ main tr:last-child td {
   animation: lb-scroll 60s linear infinite;
 }
 
-.lb-rev {
+.lb .lb-rev {
   animation-direction: reverse;
 }
 


### PR DESCRIPTION
## What broke

Two regressions introduced by #184's `.prose`-specificity fix, only visible once that same PR made the band actually render as real HTML for the first time:

1. **Both rows scroll the same direction.** `.lb .lb-track`'s `animation: lb-scroll 60s linear infinite` shorthand (specificity 0,2,0) implicitly resets `animation-direction` to `normal` as part of the shorthand. That now beats the unscoped `.lb-rev { animation-direction: reverse; }` (specificity 0,1,0) regardless of source order — so row 2 stopped reversing.
2. **Page-level horizontal scrollbar.** `.lb`'s `width: 100vw; margin-left: -50vw;` full-bleed technique overshoots the true viewport whenever a vertical scrollbar is present, because `100vw` includes the scrollbar's own width.

## Fix

- Scope `.lb-rev` to `.lb .lb-rev` (specificity 0,2,0) to restore the tie with `.lb .lb-track`.
- `overflow-x: clip` on `body` to absorb the scrollbar-width sliver — same technique the nav (`overflow-x-clip`) already uses on itself for the identical reason.

## Why a new PR

#184 already merged before these were caught live; this targets `main-pages` directly as a follow-up.

## Verification

No Jekyll build available in this sandbox (same known gap as prior PRs). Both are narrow, well-understood CSS specificity/box-model fixes; recommend a quick visual check (both rows moving opposite ways, no horizontal scrollbar) on next deploy.