### PR TITLE
fix(site): cache-bust style.css and repo-activity.js

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,17 @@
     <title>{% if page.title and page.title != 'Home' %}{{ page.title }} | {% endif %}{{ site.title }}</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
-    <link rel="stylesheet" href="{{ site.baseurl }}assets/css/style.css">
+    {%- comment -%}
+    Cache-busting query param: the live domain is proxied through Cloudflare,
+    which caches this file at its edge for cache-control's max-age (4h)
+    regardless of whether the content underneath changed — a CSS fix can be
+    built and deployed by GitHub Pages and still be invisible on the public
+    domain for hours (see #179's logo-band direction bug for exactly this).
+    A static URL is what makes that possible: Cloudflare has no way to know
+    the content changed without either a cache purge or a new URL. Appending
+    the build time makes every deploy a new URL, so there's nothing to purge.
+    {%- endcomment -%}
+    <link rel="stylesheet" href="{{ site.baseurl }}assets/css/style.css?v={{ site.time | date: '%s' }}">
     <link rel="icon" type="image/svg+xml" href="{{ site.baseurl }}assets/images/logos/BetterGov_Emblem-Outline-Inversed.svg">
     <link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}assets/images/logos/apple-touch-icon.png">
     {% seo %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,16 +6,6 @@
     <title>{% if page.title and page.title != 'Home' %}{{ page.title }} | {% endif %}{{ site.title }}</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
-    {%- comment -%}
-    Cache-busting query param: the live domain is proxied through Cloudflare,
-    which caches this file at its edge for cache-control's max-age (4h)
-    regardless of whether the content underneath changed — a CSS fix can be
-    built and deployed by GitHub Pages and still be invisible on the public
-    domain for hours (see #179's logo-band direction bug for exactly this).
-    A static URL is what makes that possible: Cloudflare has no way to know
-    the content changed without either a cache purge or a new URL. Appending
-    the build time makes every deploy a new URL, so there's nothing to purge.
-    {%- endcomment -%}
     <link rel="stylesheet" href="{{ site.baseurl }}assets/css/style.css?v={{ site.time | date: '%s' }}">
     <link rel="icon" type="image/svg+xml" href="{{ site.baseurl }}assets/images/logos/BetterGov_Emblem-Outline-Inversed.svg">
     <link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}assets/images/logos/apple-touch-icon.png">

--- a/index.md
+++ b/index.md
@@ -147,7 +147,7 @@ Content in this repository is licensed under [CC BY 4.0](LICENSE). Templates in 
 
 <!-- Repository activity (#162) — fills in the "Updated N days ago" line under
      each row's GitHub link. See assets/js/repo-activity.js. -->
-<script defer src="{{ site.baseurl }}assets/js/repo-activity.js"></script>
+<script defer src="{{ site.baseurl }}assets/js/repo-activity.js?v={{ site.time | date: '%s' }}"></script>
 
 <!-- Search and Pagination Script -->
 <script>


### PR DESCRIPTION
The live domain is proxied through Cloudflare, which caches these two files at its edge for cache-control's max-age (4h) regardless of whether the content underneath changed. A static asset URL is what makes that possible — Cloudflare has no way to know content changed without either a cache purge or a new URL.

Hit this directly on #179: GitHub Pages built and deployed the logo-band counter-scroll fix, but the public domain kept serving a pre-fix cached copy for hours, with no one on hand having Cloudflare purge access.

Appends `?v={{ site.time | date: '%s' }}` to `assets/css/style.css` and `assets/js/repo-activity.js` so every Jekyll build produces a new URL for them — Cloudflare and browsers always fetch fresh content on deploy, no purge access needed for any future change to either file.