### PR TITLE
fix(data): separate duplicate Logos across the marquee's wrap seam too

### DIFF
--- a/scripts/crawl-lgu-meta.js
+++ b/scripts/crawl-lgu-meta.js
@@ -836,6 +836,12 @@ function findDuplicateLogos(hashByDomain) {
 // duplicate of it. Resolves the realistic case (a small handful of duplicate
 // pairs) without a full optimal rearrangement — if every row in the set
 // shares one hash, adjacency can't be avoided and the run is left as-is.
+//
+// The marquee track duplicates this array end-to-end for a seamless loop
+// (logo-band.html renders `row + row` so translateX(-50%) has no visible
+// seam) — that means index 0 and the LAST index are visually adjacent too,
+// at the wrap point. So this treats the array as circular: a linear pass
+// first, then one more check across the wrap.
 function separateAdjacentDuplicates(rows, hashByDomain) {
     const arr = rows.slice();
     const hashOf = (row) => hashByDomain.get(row.domain);
@@ -846,6 +852,32 @@ function separateAdjacentDuplicates(rows, hashByDomain) {
         while (j < arr.length && hashOf(arr[j]) === h) j++;
         if (j < arr.length) {
             [arr[i + 1], arr[j]] = [arr[j], arr[i + 1]];
+        }
+    }
+    if (arr.length > 1) {
+        const wrapHash = hashOf(arr[0]);
+        if (wrapHash !== undefined && wrapHash === hashOf(arr[arr.length - 1])) {
+            // Pull the last slot's twin inward to the nearest earlier row
+            // that isn't itself a wrapHash duplicate — same greedy,
+            // best-effort approach as the linear pass above. Only commit the
+            // swap if it doesn't reintroduce a linear adjacency at the
+            // landing spot: with too few unique rows to go around (e.g. 2
+            // duplicates and only 1 unique row total), "fixing" the wrap can
+            // just relocate the same collision next to a different
+            // neighbour — in that case leave the wrap as the one unavoidable
+            // seam rather than trade one collision for another.
+            let k = arr.length - 2;
+            while (k > 0 && hashOf(arr[k]) === wrapHash) k--;
+            if (k > 0) {
+                const candidate = arr.slice();
+                [candidate[arr.length - 1], candidate[k]] = [candidate[k], candidate[arr.length - 1]];
+                const safe =
+                    hashOf(candidate[k - 1]) !== hashOf(candidate[k]) &&
+                    hashOf(candidate[k]) !== hashOf(candidate[k + 1]);
+                if (safe) {
+                    return candidate;
+                }
+            }
         }
     }
     return arr;

--- a/scripts/test-logo-eligibility.js
+++ b/scripts/test-logo-eligibility.js
@@ -252,20 +252,42 @@ console.log('\nlogoCandidates() — chain order');
     console.log('\nseparateAdjacentDuplicates() / assignRankKeys()');
 
     test('swaps an adjacent duplicate forward to break up the run', () => {
+        // Two unique rows either side of the duplicate pair — enough slack
+        // that both the linear run AND the wrap seam are fully solvable (a
+        // lone unique row can't satisfy both at once, see the "leaves a
+        // 2-duplicates-1-unique wrap unresolved" test below).
         const hashes = new Map([
+            ['w', 'unique1'],
             ['a', 'dup'],
             ['b', 'dup'],
-            ['c', 'unique'],
+            ['z', 'unique2'],
         ]);
         const separated = separateAdjacentDuplicates(
-            [{ domain: 'a' }, { domain: 'b' }, { domain: 'c' }],
+            [{ domain: 'w' }, { domain: 'a' }, { domain: 'b' }, { domain: 'z' }],
             hashes,
         );
         const domains = separated.map((r) => r.domain);
-        assert.notStrictEqual(domains[0], undefined);
         for (let i = 0; i < domains.length - 1; i++) {
             assert.notStrictEqual(hashes.get(domains[i]), hashes.get(domains[i + 1]));
         }
+        assert.notStrictEqual(hashes.get(domains[0]), hashes.get(domains[domains.length - 1]));
+    });
+
+    test('leaves a 2-duplicates-1-unique wrap unresolved rather than trade one collision for another', () => {
+        // With only one unique row to go around, the two duplicates can't
+        // avoid being adjacent SOMEWHERE in the cycle — pigeonhole. The
+        // safety check should refuse the wrap swap here rather than just
+        // relocate the same collision next to the unique row's other side.
+        const hashes = new Map([
+            ['a', 'dup'],
+            ['c', 'unique'],
+            ['b', 'dup'],
+        ]);
+        const separated = separateAdjacentDuplicates(
+            [{ domain: 'a' }, { domain: 'c' }, { domain: 'b' }],
+            hashes,
+        );
+        assert.deepStrictEqual(separated.map((r) => r.domain), ['a', 'c', 'b']);
     });
 
     test('leaves a run alone when there is nothing non-duplicate to swap in', () => {
@@ -275,6 +297,37 @@ console.log('\nlogoCandidates() — chain order');
         ]);
         const separated = separateAdjacentDuplicates([{ domain: 'a' }, { domain: 'b' }], hashes);
         assert.deepStrictEqual(separated.map((r) => r.domain), ['a', 'b']);
+    });
+
+    test('separates a duplicate pair split across the wrap seam (first + last)', () => {
+        // The marquee duplicates this array end-to-end for a seamless loop,
+        // so index 0 and the last index render next to each other even
+        // though they're not linearly adjacent in this array.
+        const hashes = new Map([
+            ['a', 'dup'],
+            ['b', 'unique1'],
+            ['c', 'unique2'],
+            ['d', 'dup'],
+        ]);
+        const separated = separateAdjacentDuplicates(
+            [{ domain: 'a' }, { domain: 'b' }, { domain: 'c' }, { domain: 'd' }],
+            hashes,
+        );
+        const domains = separated.map((r) => r.domain);
+        assert.notStrictEqual(hashes.get(domains[0]), hashes.get(domains[domains.length - 1]));
+    });
+
+    test('wrap-seam fix leaves the set alone when nothing non-duplicate exists to swap in', () => {
+        const hashes = new Map([
+            ['a', 'dup'],
+            ['b', 'dup'],
+            ['c', 'dup'],
+        ]);
+        const separated = separateAdjacentDuplicates(
+            [{ domain: 'a' }, { domain: 'b' }, { domain: 'c' }],
+            hashes,
+        );
+        assert.deepStrictEqual(separated.map((r) => r.domain), ['a', 'b', 'c']);
     });
 
     test('assignRankKeys keeps byte-identical rows apart in the resulting order', () => {


### PR DESCRIPTION
## What broke

#185's `separateAdjacentDuplicates()` only checked linear adjacency within the sorted array. But the marquee track duplicates the array end-to-end for a seamless loop (`_includes/logo-band.html` renders `row + row` so `translateX(-50%)` has no visible seam) — so index 0 and the last index are visually adjacent too, at the wrap point. A duplicate pair that landed at opposite ends of the array (one first, one last) passed the linear check untouched and showed up side by side at the loop seam. (Reported live: same logo appearing "by each side," one at the first position and one at the last.)

## Fix

Added a second pass after the linear one: if the first and last rows share a content hash, pull the last slot's twin inward to the nearest row that isn't itself a duplicate of that hash. It only commits the swap if doing so doesn't reintroduce a linear collision at the landing spot — with too few unique rows to go around (e.g. 2 duplicates and only 1 unique row total, a real pigeonhole case), "fixing" the wrap can just relocate the same collision next to a different neighbour. In that unsolvable case it leaves the wrap as-is rather than trade one collision for another.

Also had to rework the original `separateAdjacentDuplicates` happy-path test — it turned out to be exactly that unsolvable 2-duplicates/1-unique case once wrap-checking was added (a lone unique row genuinely can't separate 2 duplicates in a 3-item cycle — pigeonhole). Gave it a second unique row so both the linear run and the wrap are actually solvable, and added a case that documents the unresolvable scenario explicitly rather than leaving it unhandled.

## Verification

`node scripts/test-logo-eligibility.js` — new coverage for the wrap-seam case and the provably-unsolvable case, all passing. `test-featured-eligibility.js` and `test-crawl-reporting.js` unaffected. No live crawl run (no net egress in this sandbox).