### PR TITLE
fix(scripts): fold case in check-stale row comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the sync workflow to push merge commits even when there are no data changes.
 - Fixed a broken Better Solano Starter link and a repository link in the registration instructions.
 - Fixed Las Piñas City's Repository link to point at `betterlaspinas/betterlaspinas` instead of the maintainer's personal fork, so the repository-activity feature reads from the org repo.
+- Fixed `scripts/check-stale.js` reading a case-only relabelling as a real update, which reset an entry's idle clock and hid it from the report. A `Github` → `GitHub` fix in a table-formatting commit had masked Bacoor City as 11 days idle when it had been 37.
 
 ## [1.0.0] - 2026-04-06
 

--- a/scripts/check-stale.js
+++ b/scripts/check-stale.js
@@ -52,8 +52,19 @@ function git(args) {
 // tags are stripped so they can be judged separately by direction — see
 // isActivity. Presentation-only differences are normalized away first, so a
 // tidy-up pass over the table doesn't read as everyone updating at once:
-// whitespace is collapsed, and every way of writing an empty cell (blank, `-`,
-// `—`, `–`) folds to one marker via normalizeDash.
+// whitespace is collapsed, every way of writing an empty cell (blank, `-`, `—`,
+// `–`) folds to one marker via normalizeDash, and case is folded so relabelling
+// passes like `Github` -> `GitHub` read as the cosmetics they are.
+//
+// Case folding is deliberately lossy: an edit that changes nothing but letter
+// case no longer counts as activity, so a maintainer who only fixes their own
+// capitalization will not reset their clock. That is the safer direction to err.
+// A missed cosmetic edit silently makes an entry look fresher than it is and
+// hides it from the report; a missed real edit only surfaces an entry early,
+// where a human is already reviewing every suggestion by hand.
+//
+// The return value is compared for equality only — never printed — so lowering
+// it costs no legibility in the output.
 function comparableRow(cells) {
     return cells
         .map(cell => normalizeDash(splitCellLines(cell)
@@ -61,7 +72,8 @@ function comparableRow(cells) {
             .join(' ')))
         .join(' | ')
         .replace(/\s+/g, ' ')
-        .trim();
+        .trim()
+        .toLowerCase();
 }
 
 function rowTags(cells) {


### PR DESCRIPTION
## What

`comparableRow` in `scripts/check-stale.js` now folds case before comparing a directory row against its previous revision.

## Why

The normalizer collapsed whitespace and folded dash variants, but not letter case. A row whose only change was a relabelling therefore compared as unequal, `isActivity` returned true, and the entry's idle clock reset.

This fired once in practice. `63f3355 "style: fix table format and GitHub label format"` rewrote Bacoor City's link text from `Github` to `GitHub`. Bacoor was the only row carrying that casing typo, so it was the only entry the pass reset — from its real add date of 2026-07-10 to 2026-08-05, reading as 11 days idle instead of 37 and dropping it out of the report entirely.

The whitespace half of that same commit touched every row and was absorbed correctly, as was a later trailing-whitespace-only change in `6004b6e`. The gap was case alone.

Note the failure is one-directional and silent: a cosmetic edit can only ever make an entry look *fresher* than it is, so this class of bug hides stale entries rather than over-reporting them, and nothing in the output signals it happened.

## Tradeoff

Case folding is deliberately lossy. An edit that changes nothing but letter case no longer counts as activity, so a maintainer who only fixes their own capitalization will not reset their clock. That is the safer direction to err — a missed cosmetic edit hides an entry silently, whereas a missed real edit only surfaces an entry early, where a human is already reviewing every suggestion by hand. The reasoning is recorded in the comment above the function.

The return value is compared for equality only and never printed, so lowering it costs nothing in the output.

## Verification

- Re-ran `node scripts/check-stale.js`. Bacoor City moves to `2026-07-10 / 37d` and is the **only** row that shifts; the other 19 dates are byte-identical to the pre-fix run. Report goes from 6 suggestions to 7.
- Replayed the history walk recording *which commit* set each clock. All 20 Planned entries now trace to their own `Add <LGU> to directory` commit — every one a first appearance, none set by a later edit. No other row was masked by this bug, and the fold did not swallow a genuine update anywhere.
- Ran all five `scripts/test-*.js` suites: pass. None cover `check-stale.js` (no such suite exists), but `comparableRow` is local to that file and not exported from `sync-to-data.js`, so nothing else consumes it.

## Notes for reviewer

- `CHANGELOG.md` carries a note asking contributors not to update it in PRs. I added a `### Fixed` entry under `[Unreleased]` on the assumption that a maintainer-authored fix is in scope for that. Drop the hunk if you would rather cut it separately.
- The general shape stays open: any cosmetic edit the normalizer does not know about (link-text rewording, an emoji swap) can still reset a clock silently. A test file pinning `comparableRow`'s behaviour would be the durable fix — out of scope here.
- Newly surfaced by this fix: Bacoor City is a genuine stale candidate at 37 days, with no entry in the maintainers' check-in tracker. Tagging remains a manual call.
